### PR TITLE
Add usage/cost dashboard with token tracking and timeseries charts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ TEAMCOPILOT_PORT=5124
 # Opencode Server Configuration
 OPENCODE_PORT=4096
 OPENCODE_MODEL=openai/gpt-5.3-codex
+
+# Optional pricing overrides for the currently configured OPENCODE_MODEL.
+# Set all three or leave all three unset.
+# TEAMCOPILOT_MODEL_INPUT_PER_MILLION_USD=1.75
+# TEAMCOPILOT_MODEL_CACHED_INPUT_PER_MILLION_USD=0.175
+# TEAMCOPILOT_MODEL_OUTPUT_PER_MILLION_USD=14

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -94,6 +94,11 @@
   box-sizing: border-box;
 }
 
+.usage-panel {
+  display: flex;
+  flex-direction: column;
+}
+
 .usage-kpi-card {
   min-height: 7rem;
   display: flex;
@@ -294,42 +299,62 @@
   font-variant-numeric: tabular-nums;
 }
 
-.usage-table-wrap {
+.usage-model-list {
   width: 100%;
   max-width: 100%;
-  overflow-x: auto;
+  max-height: 28rem;
+  overflow-y: auto;
   box-sizing: border-box;
-}
-
-.usage-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.usage-table th,
-.usage-table td {
-  padding: 0.8rem 0.35rem;
-  text-align: left;
-  border-bottom: 1px solid #333;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  font-variant-numeric: tabular-nums;
-}
-
-.usage-table td::before {
-  content: none;
-}
-
-.usage-table th {
-  color: #888;
-  font-weight: 600;
-  font-size: 0.82rem;
+  display: grid;
+  gap: 0.75rem;
+  padding-right: 0.2rem;
 }
 
 .usage-model-cell {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
+  min-width: 0;
+}
+
+.usage-model-card {
+  border: 1px solid #333;
+  border-radius: 8px;
+  background: #141414;
+  padding: 0.9rem;
+}
+
+.usage-model-card-header {
+  margin-bottom: 0.8rem;
+}
+
+.usage-model-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.usage-model-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  background: #1a1a1a;
+}
+
+.usage-model-stat span {
+  color: #888;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.usage-model-stat strong {
+  font-size: 0.96rem;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
 }
 
 .usage-model-cell span,
@@ -341,6 +366,9 @@
 .usage-pricing-list {
   display: grid;
   gap: 0.75rem;
+  max-height: 28rem;
+  overflow-y: auto;
+  padding-right: 0.2rem;
 }
 
 .usage-pricing-card {
@@ -400,7 +428,6 @@
   .usage-subtitle,
   .usage-model-cell span,
   .usage-pricing-empty,
-  .usage-table th,
   .usage-legend,
   .usage-axis-labels {
     color: #666;
@@ -432,9 +459,10 @@
     border-color: #ddd;
   }
 
-  .usage-table th,
-  .usage-table td {
-    border-bottom-color: #ddd;
+  .usage-model-card,
+  .usage-model-stat {
+    border-color: #ddd;
+    background: #fff;
   }
 }
 
@@ -448,6 +476,11 @@
   .usage-chart-grid,
   .usage-detail-grid {
     grid-template-columns: 1fr;
+  }
+
+  .usage-model-list,
+  .usage-pricing-list {
+    max-height: 22rem;
   }
 }
 
@@ -530,51 +563,11 @@
     font-size: 0.8rem;
   }
 
-  .usage-table thead {
-    display: none;
-  }
-
   .usage-chart-selection-grid {
     grid-template-columns: 1fr;
   }
 
-  .usage-table,
-  .usage-table tbody {
-    display: block;
-  }
-
-  .usage-table tr {
-    display: grid;
-    gap: 0.45rem;
-    padding: 0.8rem 0;
-    border-bottom: 1px solid #333;
-  }
-
-  .usage-table tr:last-child {
-    border-bottom: none;
-  }
-
-  .usage-table td {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.75rem;
-    align-items: flex-start;
-    padding: 0;
-    border-bottom: none;
-    font-size: 0.9rem;
-  }
-
-  .usage-table td::before {
-    content: attr(data-label);
-    color: #888;
-    font-size: 0.78rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    flex: 0 0 auto;
-  }
-
-  .usage-model-cell {
-    align-items: flex-end;
-    text-align: right;
+  .usage-model-stats-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -102,11 +102,12 @@
 }
 
 .usage-kpi-card strong {
-  font-size: clamp(1.15rem, 1.8vw, 1.85rem);
+  font-size: clamp(1rem, 1.55vw, 1.55rem);
   letter-spacing: -0.04em;
   line-height: 1.05;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-variant-numeric: tabular-nums;
 }
 
@@ -307,11 +308,54 @@
 .usage-pricing-card {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
-  padding: 0.9rem 1rem;
+  gap: 0.8rem;
+  padding: 1rem;
   border-radius: 8px;
   border: 1px solid #333;
   background: #141414;
+}
+
+.usage-pricing-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.usage-pricing-card-header strong {
+  font-size: 1rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.usage-pricing-card-header span {
+  color: #888;
+  font-size: 0.8rem;
+}
+
+.usage-pricing-rate-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.usage-pricing-rate-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  background: #1a1a1a;
+}
+
+.usage-pricing-rate-row span {
+  color: #aaa;
+}
+
+.usage-pricing-rate-row strong {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 @media (prefers-color-scheme: light) {
@@ -337,6 +381,11 @@
   .usage-bar-rail,
   .usage-chart-empty {
     background: #f5f5f5;
+    border-color: #ddd;
+  }
+
+  .usage-pricing-rate-row {
+    background: #fff;
     border-color: #ddd;
   }
 

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -1,0 +1,321 @@
+.usage-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.usage-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.usage-header h2,
+.usage-chart-header h3,
+.usage-panel-header h3 {
+  margin: 0;
+}
+
+.usage-subtitle {
+  margin: 0.4rem 0 0;
+  color: #8c92a8;
+  max-width: 52rem;
+}
+
+.usage-range-picker {
+  display: inline-flex;
+  gap: 0.35rem;
+  padding: 0.3rem;
+  border: 1px solid #2f3a52;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at top left, rgba(80, 140, 255, 0.14), transparent 48%),
+    rgba(12, 17, 29, 0.88);
+}
+
+.usage-range-btn {
+  border: none;
+  background: transparent;
+  color: #aab2c9;
+  border-radius: 999px;
+  padding: 0.55rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+.usage-range-btn.active {
+  background: linear-gradient(135deg, #3f6ef7, #2ca6a4);
+  color: white;
+}
+
+.usage-kpi-grid,
+.usage-chart-grid,
+.usage-detail-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.usage-kpi-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.usage-chart-grid,
+.usage-detail-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.usage-kpi-card,
+.usage-chart-card,
+.usage-panel {
+  border: 1px solid #283247;
+  border-radius: 22px;
+  padding: 1rem;
+  background:
+    linear-gradient(180deg, rgba(17, 24, 39, 0.95), rgba(11, 16, 27, 0.98)),
+    #0d1320;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.28);
+}
+
+.usage-kpi-card {
+  min-height: 7rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.usage-kpi-card strong {
+  font-size: clamp(1.35rem, 2vw, 2rem);
+  letter-spacing: -0.04em;
+}
+
+.usage-kpi-label {
+  color: #98a2b9;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+}
+
+.usage-chart-header,
+.usage-panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.9rem;
+}
+
+.usage-bars,
+.usage-stacked-bars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14px, 1fr));
+  gap: 0.45rem;
+  align-items: end;
+  height: 220px;
+  padding: 0.75rem 0 0;
+}
+
+.usage-bar-column {
+  height: 100%;
+  display: flex;
+  align-items: end;
+}
+
+.usage-bar,
+.usage-stacked-bar {
+  width: 100%;
+  border-radius: 999px 999px 0 0;
+}
+
+.usage-bar {
+  min-height: 6px;
+}
+
+.usage-bar.cost {
+  background: linear-gradient(180deg, #6ea8fe, #1f6feb);
+}
+
+.usage-stacked-bar {
+  height: 100%;
+  display: flex;
+  flex-direction: column-reverse;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.usage-stacked-segment.input,
+.usage-legend i.input {
+  background: #4f8cff;
+}
+
+.usage-stacked-segment.output,
+.usage-legend i.output {
+  background: #14b8a6;
+}
+
+.usage-stacked-segment.cached,
+.usage-legend i.cached {
+  background: #f59e0b;
+}
+
+.usage-axis-labels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14px, 1fr));
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+  color: #77809b;
+  font-size: 0.72rem;
+}
+
+.usage-axis-labels span {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  text-align: left;
+}
+
+.usage-legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.8rem;
+  color: #9ba4bc;
+  font-size: 0.84rem;
+}
+
+.usage-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.usage-legend i {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.usage-table-wrap {
+  overflow-x: auto;
+}
+
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.usage-table th,
+.usage-table td {
+  padding: 0.8rem 0.35rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.usage-table th {
+  color: #8e98b3;
+  font-weight: 600;
+  font-size: 0.82rem;
+}
+
+.usage-model-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.usage-model-cell span,
+.usage-pricing-empty {
+  color: #8e98b3;
+  font-size: 0.82rem;
+}
+
+.usage-pricing-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.usage-pricing-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(96, 165, 250, 0.18);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+@media (prefers-color-scheme: light) {
+  .usage-subtitle,
+  .usage-model-cell span,
+  .usage-pricing-empty,
+  .usage-table th,
+  .usage-legend,
+  .usage-axis-labels {
+    color: #5b6478;
+  }
+
+  .usage-range-picker,
+  .usage-kpi-card,
+  .usage-chart-card,
+  .usage-panel {
+    border-color: #d8dfeb;
+    background:
+      radial-gradient(circle at top left, rgba(80, 140, 255, 0.12), transparent 48%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 247, 252, 0.98));
+    box-shadow: 0 16px 32px rgba(148, 163, 184, 0.14);
+  }
+
+  .usage-stacked-bar,
+  .usage-pricing-card {
+    background: rgba(226, 232, 240, 0.45);
+  }
+}
+
+@media (max-width: 1100px) {
+  .usage-kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 860px) {
+  .usage-chart-grid,
+  .usage-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .usage-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .usage-header {
+    flex-direction: column;
+  }
+
+  .usage-range-picker {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .usage-range-btn {
+    flex: 1 1 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .usage-kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .usage-chart-card,
+  .usage-panel,
+  .usage-kpi-card {
+    border-radius: 18px;
+  }
+
+  .usage-bars,
+  .usage-stacked-bars {
+    height: 180px;
+  }
+}

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -3,6 +3,10 @@
   flex-direction: column;
   gap: 1.25rem;
   min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  box-sizing: border-box;
 }
 
 .usage-header {
@@ -11,6 +15,14 @@
   gap: 1rem;
   align-items: flex-start;
   flex-wrap: wrap;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.usage-header > div:first-child {
+  min-width: 0;
 }
 
 .usage-header h2,
@@ -32,6 +44,7 @@
   border: 1px solid #333;
   border-radius: 999px;
   background: #1a1a1a;
+  box-sizing: border-box;
 }
 
 .usage-range-btn {
@@ -54,6 +67,9 @@
   display: grid;
   gap: 1rem;
   min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .usage-kpi-grid {
@@ -75,6 +91,7 @@
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
+  box-sizing: border-box;
 }
 
 .usage-kpi-card {
@@ -123,6 +140,7 @@
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 0.35rem;
+  box-sizing: border-box;
 }
 
 .usage-chart-scroll-inner {
@@ -238,7 +256,10 @@
 }
 
 .usage-table-wrap {
+  width: 100%;
+  max-width: 100%;
   overflow-x: auto;
+  box-sizing: border-box;
 }
 
 .usage-table {
@@ -347,14 +368,19 @@
     flex-direction: column;
   }
 
+  .usage-header > div:first-child {
+    width: 100%;
+  }
+
   .usage-range-picker {
     width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
   }
 
   .usage-range-btn {
-    flex: 1 1 calc(50% - 0.35rem);
+    width: 100%;
     min-width: 0;
   }
 
@@ -398,14 +424,13 @@
   }
 
   .usage-range-picker {
-    gap: 0.4rem;
+    gap: 0.45rem;
     padding: 0.4rem;
-    border-radius: 18px;
+    border-radius: 14px;
   }
 
   .usage-range-btn {
-    flex: 1 1 calc(50% - 0.4rem);
-    padding: 0.65rem 0.7rem;
+    padding: 0.75rem 0.7rem;
   }
 
   .usage-legend {

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -82,11 +82,17 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .usage-kpi-card strong {
-  font-size: clamp(1.35rem, 2vw, 2rem);
+  font-size: clamp(1.15rem, 1.8vw, 1.85rem);
   letter-spacing: -0.04em;
+  line-height: 1.05;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-variant-numeric: tabular-nums;
 }
 
 .usage-kpi-label {
@@ -105,42 +111,67 @@
   margin-bottom: 0.9rem;
 }
 
-.usage-bars,
-.usage-stacked-bars {
+.usage-chart-header span {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.usage-chart-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.35rem;
+}
+
+.usage-chart-scroll-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.usage-bars {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(14px, 1fr));
-  gap: 0.45rem;
+  gap: 0.75rem;
   align-items: end;
-  height: 220px;
-  padding: 0.75rem 0 0;
+  height: 240px;
+  padding: 0.5rem 0 0;
 }
 
 .usage-bar-column {
   height: 100%;
   display: flex;
   align-items: end;
+  min-width: 0;
+}
+
+.usage-bar-rail {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: end;
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
+  padding: 0.25rem;
 }
 
 .usage-bar,
 .usage-stacked-bar {
   width: 100%;
-  border-radius: 999px 999px 0 0;
-}
-
-.usage-bar {
-  min-height: 6px;
+  border-radius: 12px 12px 8px 8px;
 }
 
 .usage-bar.cost {
-  background: linear-gradient(180deg, #6ea8fe, #1f6feb);
+  background: linear-gradient(180deg, #8bc5ff, #2d74ff 65%, #1f5ae0);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
 .usage-stacked-bar {
-  height: 100%;
   display: flex;
   flex-direction: column-reverse;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.04);
+  min-height: 0;
 }
 
 .usage-stacked-segment.input,
@@ -160,17 +191,25 @@
 
 .usage-axis-labels {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(14px, 1fr));
-  gap: 0.45rem;
-  margin-top: 0.75rem;
+  gap: 0.75rem;
   color: #77809b;
-  font-size: 0.72rem;
+  font-size: 0.75rem;
 }
 
 .usage-axis-labels span {
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  text-align: left;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.usage-chart-empty {
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  color: #8e98b3;
+  background: rgba(15, 23, 42, 0.28);
 }
 
 .usage-legend {
@@ -209,6 +248,9 @@
   padding: 0.8rem 0.35rem;
   text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-variant-numeric: tabular-nums;
 }
 
 .usage-table th {
@@ -266,7 +308,9 @@
   }
 
   .usage-stacked-bar,
-  .usage-pricing-card {
+  .usage-pricing-card,
+  .usage-bar-rail,
+  .usage-chart-empty {
     background: rgba(226, 232, 240, 0.45);
   }
 }
@@ -314,8 +358,11 @@
     border-radius: 18px;
   }
 
-  .usage-bars,
-  .usage-stacked-bars {
+  .usage-bars {
     height: 180px;
+  }
+
+  .usage-chart-empty {
+    min-height: 180px;
   }
 }

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  min-width: 0;
 }
 
 .usage-header {
@@ -54,6 +55,7 @@
 .usage-detail-grid {
   display: grid;
   gap: 1rem;
+  min-width: 0;
 }
 
 .usage-kpi-grid {
@@ -75,6 +77,9 @@
     linear-gradient(180deg, rgba(17, 24, 39, 0.95), rgba(11, 16, 27, 0.98)),
     #0d1320;
   box-shadow: 0 18px 40px rgba(2, 6, 23, 0.28);
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .usage-kpi-card {
@@ -118,6 +123,9 @@
 }
 
 .usage-chart-scroll {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 0.35rem;
@@ -127,6 +135,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  width: max-content;
+  max-width: none;
 }
 
 .usage-bars {
@@ -253,6 +263,10 @@
   font-variant-numeric: tabular-nums;
 }
 
+.usage-table td::before {
+  content: none;
+}
+
 .usage-table th {
   color: #8e98b3;
   font-weight: 600;
@@ -339,11 +353,23 @@
 
   .usage-range-picker {
     width: 100%;
-    justify-content: space-between;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .usage-range-btn {
-    flex: 1 1 0;
+    flex: 1 1 calc(50% - 0.35rem);
+    min-width: 0;
+  }
+
+  .usage-chart-header,
+  .usage-panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .usage-chart-header span {
+    text-align: left;
   }
 }
 
@@ -356,6 +382,7 @@
   .usage-panel,
   .usage-kpi-card {
     border-radius: 18px;
+    padding: 0.85rem;
   }
 
   .usage-bars {
@@ -364,5 +391,73 @@
 
   .usage-chart-empty {
     min-height: 180px;
+  }
+
+  .usage-header h2 {
+    font-size: 1.35rem;
+  }
+
+  .usage-subtitle {
+    font-size: 0.92rem;
+  }
+
+  .usage-range-picker {
+    gap: 0.4rem;
+    padding: 0.4rem;
+    border-radius: 18px;
+  }
+
+  .usage-range-btn {
+    flex: 1 1 calc(50% - 0.4rem);
+    padding: 0.65rem 0.7rem;
+  }
+
+  .usage-legend {
+    gap: 0.65rem;
+    font-size: 0.8rem;
+  }
+
+  .usage-table thead {
+    display: none;
+  }
+
+  .usage-table,
+  .usage-table tbody {
+    display: block;
+  }
+
+  .usage-table tr {
+    display: grid;
+    gap: 0.45rem;
+    padding: 0.8rem 0;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  }
+
+  .usage-table tr:last-child {
+    border-bottom: none;
+  }
+
+  .usage-table td {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 0;
+    border-bottom: none;
+    font-size: 0.9rem;
+  }
+
+  .usage-table td::before {
+    content: attr(data-label);
+    color: #8e98b3;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    flex: 0 0 auto;
+  }
+
+  .usage-model-cell {
+    align-items: flex-end;
+    text-align: right;
   }
 }

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -21,7 +21,7 @@
 
 .usage-subtitle {
   margin: 0.4rem 0 0;
-  color: #8c92a8;
+  color: #888;
   max-width: 52rem;
 }
 
@@ -29,25 +29,23 @@
   display: inline-flex;
   gap: 0.35rem;
   padding: 0.3rem;
-  border: 1px solid #2f3a52;
+  border: 1px solid #333;
   border-radius: 999px;
-  background:
-    radial-gradient(circle at top left, rgba(80, 140, 255, 0.14), transparent 48%),
-    rgba(12, 17, 29, 0.88);
+  background: #1a1a1a;
 }
 
 .usage-range-btn {
   border: none;
   background: transparent;
-  color: #aab2c9;
+  color: #aaa;
   border-radius: 999px;
   padding: 0.55rem 0.9rem;
   font-size: 0.9rem;
 }
 
 .usage-range-btn.active {
-  background: linear-gradient(135deg, #3f6ef7, #2ca6a4);
-  color: white;
+  background: rgba(100, 108, 255, 0.14);
+  color: #e5e7eb;
 }
 
 .usage-kpi-grid,
@@ -70,13 +68,10 @@
 .usage-kpi-card,
 .usage-chart-card,
 .usage-panel {
-  border: 1px solid #283247;
-  border-radius: 22px;
+  border: 1px solid #333;
+  border-radius: 8px;
   padding: 1rem;
-  background:
-    linear-gradient(180deg, rgba(17, 24, 39, 0.95), rgba(11, 16, 27, 0.98)),
-    #0d1320;
-  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.28);
+  background: #1a1a1a;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -87,8 +82,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-width: 0;
-  overflow: hidden;
 }
 
 .usage-kpi-card strong {
@@ -101,7 +94,7 @@
 }
 
 .usage-kpi-label {
-  color: #98a2b9;
+  color: #888;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
@@ -120,6 +113,7 @@
   text-align: right;
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
+  color: #aaa;
 }
 
 .usage-chart-scroll {
@@ -159,39 +153,38 @@
   height: 100%;
   display: flex;
   align-items: end;
-  border-radius: 16px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
+  border-radius: 8px;
+  background: #141414;
+  border: 1px solid #2a2a2a;
   padding: 0.25rem;
 }
 
 .usage-bar,
 .usage-stacked-bar {
   width: 100%;
-  border-radius: 12px 12px 8px 8px;
+  border-radius: 6px 6px 4px 4px;
 }
 
 .usage-bar.cost {
-  background: linear-gradient(180deg, #8bc5ff, #2d74ff 65%, #1f5ae0);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  background: #646cff;
 }
 
 .usage-stacked-bar {
   display: flex;
   flex-direction: column-reverse;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.04);
+  background: #202020;
   min-height: 0;
 }
 
 .usage-stacked-segment.input,
 .usage-legend i.input {
-  background: #4f8cff;
+  background: #646cff;
 }
 
 .usage-stacked-segment.output,
 .usage-legend i.output {
-  background: #14b8a6;
+  background: #3b82f6;
 }
 
 .usage-stacked-segment.cached,
@@ -202,7 +195,7 @@
 .usage-axis-labels {
   display: grid;
   gap: 0.75rem;
-  color: #77809b;
+  color: #888;
   font-size: 0.75rem;
 }
 
@@ -216,10 +209,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px dashed rgba(148, 163, 184, 0.2);
-  border-radius: 18px;
-  color: #8e98b3;
-  background: rgba(15, 23, 42, 0.28);
+  border: 1px dashed #444;
+  border-radius: 8px;
+  color: #888;
+  background: #141414;
 }
 
 .usage-legend {
@@ -227,7 +220,7 @@
   gap: 1rem;
   flex-wrap: wrap;
   margin-top: 0.8rem;
-  color: #9ba4bc;
+  color: #aaa;
   font-size: 0.84rem;
 }
 
@@ -257,7 +250,7 @@
 .usage-table td {
   padding: 0.8rem 0.35rem;
   text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  border-bottom: 1px solid #333;
   overflow-wrap: anywhere;
   word-break: break-word;
   font-variant-numeric: tabular-nums;
@@ -268,7 +261,7 @@
 }
 
 .usage-table th {
-  color: #8e98b3;
+  color: #888;
   font-weight: 600;
   font-size: 0.82rem;
 }
@@ -281,7 +274,7 @@
 
 .usage-model-cell span,
 .usage-pricing-empty {
-  color: #8e98b3;
+  color: #888;
   font-size: 0.82rem;
 }
 
@@ -295,9 +288,9 @@
   flex-direction: column;
   gap: 0.3rem;
   padding: 0.9rem 1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(96, 165, 250, 0.18);
-  background: rgba(15, 23, 42, 0.72);
+  border-radius: 8px;
+  border: 1px solid #333;
+  background: #141414;
 }
 
 @media (prefers-color-scheme: light) {
@@ -307,25 +300,28 @@
   .usage-table th,
   .usage-legend,
   .usage-axis-labels {
-    color: #5b6478;
+    color: #666;
   }
 
   .usage-range-picker,
   .usage-kpi-card,
   .usage-chart-card,
   .usage-panel {
-    border-color: #d8dfeb;
-    background:
-      radial-gradient(circle at top left, rgba(80, 140, 255, 0.12), transparent 48%),
-      linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 247, 252, 0.98));
-    box-shadow: 0 16px 32px rgba(148, 163, 184, 0.14);
+    border-color: #ddd;
+    background: #fff;
   }
 
   .usage-stacked-bar,
   .usage-pricing-card,
   .usage-bar-rail,
   .usage-chart-empty {
-    background: rgba(226, 232, 240, 0.45);
+    background: #f5f5f5;
+    border-color: #ddd;
+  }
+
+  .usage-table th,
+  .usage-table td {
+    border-bottom-color: #ddd;
   }
 }
 
@@ -381,7 +377,7 @@
   .usage-chart-card,
   .usage-panel,
   .usage-kpi-card {
-    border-radius: 18px;
+    border-radius: 8px;
     padding: 0.85rem;
   }
 
@@ -430,7 +426,7 @@
     display: grid;
     gap: 0.45rem;
     padding: 0.8rem 0;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+    border-bottom: 1px solid #333;
   }
 
   .usage-table tr:last-child {
@@ -449,7 +445,7 @@
 
   .usage-table td::before {
     content: attr(data-label);
-    color: #8e98b3;
+    color: #888;
     font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -162,7 +162,7 @@
   gap: 0.75rem;
   align-items: end;
   height: 240px;
-  padding: 0.5rem 0 0;
+  padding: 1rem 0 0;
 }
 
 .usage-bar-column {
@@ -197,12 +197,12 @@
   background: transparent;
   display: flex;
   align-items: flex-end;
+  box-sizing: border-box;
 }
 
 .usage-bar-button.selected {
-  outline: 2px solid rgba(100, 108, 255, 0.5);
-  outline-offset: 2px;
   border-radius: 6px;
+  box-shadow: inset 0 0 0 2px rgba(100, 108, 255, 0.65);
 }
 
 .usage-bar.cost {

--- a/frontend/src/components/dashboard/UsageSection.css
+++ b/frontend/src/components/dashboard/UsageSection.css
@@ -184,6 +184,22 @@
   border-radius: 6px 6px 4px 4px;
 }
 
+.usage-bar-button {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: flex-end;
+}
+
+.usage-bar-button.selected {
+  outline: 2px solid rgba(100, 108, 255, 0.5);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
 .usage-bar.cost {
   background: #646cff;
 }
@@ -254,6 +270,28 @@
   height: 0.75rem;
   border-radius: 999px;
   display: inline-block;
+}
+
+.usage-chart-selection {
+  margin-top: 0.85rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid #333;
+  border-radius: 8px;
+  background: #141414;
+}
+
+.usage-chart-selection strong {
+  display: block;
+  margin-bottom: 0.45rem;
+}
+
+.usage-chart-selection-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem 0.75rem;
+  color: #aaa;
+  font-size: 0.9rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .usage-table-wrap {
@@ -384,6 +422,11 @@
     border-color: #ddd;
   }
 
+  .usage-chart-selection {
+    background: #f5f5f5;
+    border-color: #ddd;
+  }
+
   .usage-pricing-rate-row {
     background: #fff;
     border-color: #ddd;
@@ -489,6 +532,10 @@
 
   .usage-table thead {
     display: none;
+  }
+
+  .usage-chart-selection-grid {
+    grid-template-columns: 1fr;
   }
 
   .usage-table,

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -80,6 +80,14 @@ function formatBucketLabel(timestamp: number, range: UsageRange): string {
     return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
 }
 
+function formatBucketDateTime(timestamp: number, range: UsageRange): string {
+    const date = new Date(timestamp);
+    if (range === '24h') {
+        return date.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+    }
+    return date.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
 function ChartScroller({
     children,
     points,
@@ -97,7 +105,17 @@ function ChartScroller({
     );
 }
 
-function CostBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) {
+function CostBars({
+    data,
+    range,
+    selectedBucketStart,
+    onSelectBucket,
+}: {
+    data: UsageBucket[];
+    range: UsageRange;
+    selectedBucketStart: number;
+    onSelectBucket: (bucketStart: number) => void;
+}) {
     const maxValue = Math.max(...data.map((item) => item.cost_usd), 0);
     const gridTemplateColumns = `repeat(${Math.max(data.length, 1)}, minmax(32px, 1fr))`;
 
@@ -111,10 +129,18 @@ function CostBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) {
                 {data.map((item) => {
                     const value = item.cost_usd;
                     const height = (value / maxValue) * 100;
+                    const isSelected = selectedBucketStart === item.bucket_start;
                     return (
                         <div key={`cost-${item.bucket_start}`} className="usage-bar-column">
                             <div className="usage-bar-rail">
-                                <div className="usage-bar cost" style={{ height: `${height}%` }} />
+                                <button
+                                    type="button"
+                                    className={`usage-bar-button ${isSelected ? 'selected' : ''}`}
+                                    onClick={() => onSelectBucket(item.bucket_start)}
+                                    aria-label={`Show cost details for ${formatBucketDateTime(item.bucket_start, range)}`}
+                                >
+                                    <div className="usage-bar cost" style={{ height: `${height}%` }} />
+                                </button>
                             </div>
                         </div>
                     );
@@ -129,7 +155,17 @@ function CostBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) {
     );
 }
 
-function TokenBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) {
+function TokenBars({
+    data,
+    range,
+    selectedBucketStart,
+    onSelectBucket,
+}: {
+    data: UsageBucket[];
+    range: UsageRange;
+    selectedBucketStart: number;
+    onSelectBucket: (bucketStart: number) => void;
+}) {
     const totals = data.map((bucket) => bucket.input_tokens + bucket.output_tokens + bucket.cached_tokens);
     const maxTotal = Math.max(...totals, 0);
     const gridTemplateColumns = `repeat(${Math.max(data.length, 1)}, minmax(32px, 1fr))`;
@@ -147,14 +183,22 @@ function TokenBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) 
                     const inputHeight = bucketTotal === 0 ? 0 : (item.input_tokens / bucketTotal) * 100;
                     const outputHeight = bucketTotal === 0 ? 0 : (item.output_tokens / bucketTotal) * 100;
                     const cachedHeight = bucketTotal === 0 ? 0 : (item.cached_tokens / bucketTotal) * 100;
+                    const isSelected = selectedBucketStart === item.bucket_start;
                     return (
                         <div key={`tokens-${item.bucket_start}`} className="usage-bar-column">
                             <div className="usage-bar-rail">
-                                <div className="usage-stacked-bar" style={{ height: `${stackHeight}%` }}>
-                                    <div className="usage-stacked-segment input" style={{ height: `${inputHeight}%` }} />
-                                    <div className="usage-stacked-segment output" style={{ height: `${outputHeight}%` }} />
-                                    <div className="usage-stacked-segment cached" style={{ height: `${cachedHeight}%` }} />
-                                </div>
+                                <button
+                                    type="button"
+                                    className={`usage-bar-button ${isSelected ? 'selected' : ''}`}
+                                    onClick={() => onSelectBucket(item.bucket_start)}
+                                    aria-label={`Show token details for ${formatBucketDateTime(item.bucket_start, range)}`}
+                                >
+                                    <div className="usage-stacked-bar" style={{ height: `${stackHeight}%` }}>
+                                        <div className="usage-stacked-segment input" style={{ height: `${inputHeight}%` }} />
+                                        <div className="usage-stacked-segment output" style={{ height: `${outputHeight}%` }} />
+                                        <div className="usage-stacked-segment cached" style={{ height: `${cachedHeight}%` }} />
+                                    </div>
+                                </button>
                             </div>
                         </div>
                     );
@@ -176,6 +220,8 @@ export default function UsageSection() {
     const [data, setData] = useState<UsageOverviewResponse | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [selectedCostBucketStart, setSelectedCostBucketStart] = useState<number | null>(null);
+    const [selectedTokenBucketStart, setSelectedTokenBucketStart] = useState<number | null>(null);
 
     useEffect(() => {
         if (!token) {
@@ -191,6 +237,9 @@ export default function UsageSection() {
                     headers: { Authorization: `Bearer ${token}` }
                 });
                 setData(response.data);
+                const defaultBucketStart = response.data.timeseries.at(-1)?.bucket_start ?? null;
+                setSelectedCostBucketStart(defaultBucketStart);
+                setSelectedTokenBucketStart(defaultBucketStart);
             } catch (err: unknown) {
                 const errorMessage = err instanceof AxiosError ? err.response?.data?.message || err.response?.data || err.message : 'Failed to load usage overview';
                 setError(errorMessage);
@@ -229,6 +278,8 @@ export default function UsageSection() {
     }
 
     const shouldHideCosting = totalTokens > 0 && data.summary.total_cost_usd === 0;
+    const selectedCostBucket = data.timeseries.find((bucket) => bucket.bucket_start === selectedCostBucketStart) ?? data.timeseries.at(-1) ?? null;
+    const selectedTokenBucket = data.timeseries.find((bucket) => bucket.bucket_start === selectedTokenBucketStart) ?? data.timeseries.at(-1) ?? null;
 
     return (
         <section className="usage-section">
@@ -294,16 +345,46 @@ export default function UsageSection() {
                             <h3>Estimated Cost Over Time</h3>
                             <span>{formatUsd(data.summary.total_cost_usd)}</span>
                         </div>
-                        <CostBars data={data.timeseries} range={data.range} />
+                        <CostBars
+                            data={data.timeseries}
+                            range={data.range}
+                            selectedBucketStart={selectedCostBucket?.bucket_start ?? 0}
+                            onSelectBucket={setSelectedCostBucketStart}
+                        />
+                        {selectedCostBucket ? (
+                            <div className="usage-chart-selection">
+                                <strong>{formatBucketDateTime(selectedCostBucket.bucket_start, data.range)}</strong>
+                                <div className="usage-chart-selection-grid">
+                                    <span>Cost: {formatUsd(selectedCostBucket.cost_usd)}</span>
+                                    <span>Sessions: {formatTokenCount(selectedCostBucket.session_count)}</span>
+                                </div>
+                            </div>
+                        ) : null}
                     </article>
                 ) : null}
 
                 <article className="usage-chart-card">
-                    <div className="usage-chart-header">
-                        <h3>Token Usage Over Time</h3>
-                        <span>{formatTokenCount(totalTokens)}</span>
-                    </div>
-                    <TokenBars data={data.timeseries} range={data.range} />
+                        <div className="usage-chart-header">
+                            <h3>Token Usage Over Time</h3>
+                            <span>{formatTokenCount(totalTokens)}</span>
+                        </div>
+                    <TokenBars
+                        data={data.timeseries}
+                        range={data.range}
+                        selectedBucketStart={selectedTokenBucket?.bucket_start ?? 0}
+                        onSelectBucket={setSelectedTokenBucketStart}
+                    />
+                    {selectedTokenBucket ? (
+                        <div className="usage-chart-selection">
+                            <strong>{formatBucketDateTime(selectedTokenBucket.bucket_start, data.range)}</strong>
+                            <div className="usage-chart-selection-grid">
+                                <span>Input: {formatTokenCount(selectedTokenBucket.input_tokens)}</span>
+                                <span>Output: {formatTokenCount(selectedTokenBucket.output_tokens)}</span>
+                                <span>Cached: {formatTokenCount(selectedTokenBucket.cached_tokens)}</span>
+                                <span>Sessions: {formatTokenCount(selectedTokenBucket.session_count)}</span>
+                            </div>
+                        </div>
+                    ) : null}
                     <div className="usage-legend">
                         <span><i className="input" />Input</span>
                         <span><i className="output" />Output</span>

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -55,6 +55,14 @@ function formatTokenCount(value: number): string {
     }).format(value);
 }
 
+function formatKpiTokenCount(value: number): string {
+    return new Intl.NumberFormat(undefined, {
+        notation: value >= 1000 ? 'compact' : 'standard',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+    }).format(value);
+}
+
 function formatUsd(value: number): string {
     return new Intl.NumberFormat(undefined, {
         style: 'currency',
@@ -249,28 +257,33 @@ export default function UsageSection() {
                 {!shouldHideCosting ? (
                     <article className="usage-kpi-card">
                         <span className="usage-kpi-label">Estimated Cost</span>
-                        <strong>{formatUsd(data.summary.total_cost_usd)}</strong>
+                        <strong>{new Intl.NumberFormat(undefined, {
+                            style: 'currency',
+                            currency: 'USD',
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                        }).format(data.summary.total_cost_usd)}</strong>
                     </article>
                 ) : null}
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Total Tokens</span>
-                    <strong>{formatTokenCount(totalTokens)}</strong>
+                    <strong>{formatKpiTokenCount(totalTokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Input Tokens</span>
-                    <strong>{formatTokenCount(data.summary.total_input_tokens)}</strong>
+                    <strong>{formatKpiTokenCount(data.summary.total_input_tokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Output Tokens</span>
-                    <strong>{formatTokenCount(data.summary.total_output_tokens)}</strong>
+                    <strong>{formatKpiTokenCount(data.summary.total_output_tokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Cached Tokens</span>
-                    <strong>{formatTokenCount(data.summary.total_cached_tokens)}</strong>
+                    <strong>{formatKpiTokenCount(data.summary.total_cached_tokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Tracked Sessions</span>
-                    <strong>{formatTokenCount(data.summary.session_count)}</strong>
+                    <strong>{formatKpiTokenCount(data.summary.session_count)}</strong>
                 </article>
             </div>
 
@@ -345,10 +358,24 @@ export default function UsageSection() {
                         <div className="usage-pricing-list">
                             {Object.entries(data.pricing).map(([modelId, pricingEntry]) => (
                                 <div key={modelId} className="usage-pricing-card">
-                                    <strong>{modelId}</strong>
-                                    <span>Input: {formatUsd(pricingEntry.input_per_million_usd)}/1M</span>
-                                    <span>Cached: {formatUsd(pricingEntry.cached_input_per_million_usd)}/1M</span>
-                                    <span>Output: {formatUsd(pricingEntry.output_per_million_usd)}/1M</span>
+                                    <div className="usage-pricing-card-header">
+                                        <strong>{modelId}</strong>
+                                        <span>Per 1M tokens</span>
+                                    </div>
+                                    <div className="usage-pricing-rate-list">
+                                        <div className="usage-pricing-rate-row">
+                                            <span>Input</span>
+                                            <strong>{formatUsd(pricingEntry.input_per_million_usd)}</strong>
+                                        </div>
+                                        <div className="usage-pricing-rate-row">
+                                            <span>Cached</span>
+                                            <strong>{formatUsd(pricingEntry.cached_input_per_million_usd)}</strong>
+                                        </div>
+                                        <div className="usage-pricing-rate-row">
+                                            <span>Output</span>
+                                            <strong>{formatUsd(pricingEntry.output_per_million_usd)}</strong>
+                                        </div>
+                                    </div>
                                 </div>
                             ))}
                             {Object.keys(data.pricing).length === 0 ? (

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AxiosError } from 'axios';
+import { useAuth } from '../../lib/auth';
+import { axiosInstance } from '../../utils';
+import './UsageSection.css';
+
+type UsageRange = '24h' | '7d' | '30d' | '90d';
+
+type UsageBucket = {
+    bucket_start: number;
+    input_tokens: number;
+    output_tokens: number;
+    cached_tokens: number;
+    cost_usd: number;
+    session_count: number;
+};
+
+type ModelUsage = {
+    model_id: string;
+    input_tokens: number;
+    output_tokens: number;
+    cached_tokens: number;
+    cost_usd: number;
+    session_count: number;
+    pricing_available: boolean;
+};
+
+type PricingEntry = {
+    input_per_million_usd: number;
+    cached_input_per_million_usd: number;
+    output_per_million_usd: number;
+};
+
+type UsageOverviewResponse = {
+    range: UsageRange;
+    estimated: boolean;
+    summary: {
+        total_input_tokens: number;
+        total_output_tokens: number;
+        total_cached_tokens: number;
+        total_cost_usd: number;
+        session_count: number;
+    };
+    timeseries: UsageBucket[];
+    models: ModelUsage[];
+    pricing: Record<string, PricingEntry>;
+};
+
+const RANGE_OPTIONS: UsageRange[] = ['24h', '7d', '30d', '90d'];
+
+function formatTokenCount(value: number): string {
+    return new Intl.NumberFormat(undefined, {
+        notation: value >= 1000 ? 'compact' : 'standard',
+        maximumFractionDigits: value >= 1000 ? 1 : 0,
+    }).format(value);
+}
+
+function formatUsd(value: number): string {
+    return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: value < 1 ? 4 : 2,
+        maximumFractionDigits: value < 1 ? 4 : 2,
+    }).format(value);
+}
+
+function formatBucketLabel(timestamp: number, range: UsageRange): string {
+    const date = new Date(timestamp);
+    if (range === '24h') {
+        return date.toLocaleTimeString([], { hour: 'numeric' });
+    }
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function SimpleBars({
+    data,
+    colorClass,
+    valueKey,
+}: {
+    data: UsageBucket[];
+    colorClass: string;
+    valueKey: 'cost_usd' | 'input_tokens' | 'output_tokens' | 'cached_tokens';
+}) {
+    const maxValue = Math.max(...data.map((item) => item[valueKey]), 0);
+
+    return (
+        <div className="usage-bars">
+            {data.map((item) => {
+                const value = item[valueKey];
+                const height = maxValue === 0 ? 6 : Math.max(6, (value / maxValue) * 100);
+                return (
+                    <div key={`${valueKey}-${item.bucket_start}`} className="usage-bar-column">
+                        <div className={`usage-bar ${colorClass}`} style={{ height: `${height}%` }} />
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+export default function UsageSection() {
+    const auth = useAuth();
+    const token = auth.loading ? null : auth.token;
+    const [range, setRange] = useState<UsageRange>('7d');
+    const [data, setData] = useState<UsageOverviewResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!token) {
+            return;
+        }
+
+        const fetchUsage = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await axiosInstance.get<UsageOverviewResponse>('/api/usage/overview', {
+                    params: { range },
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                setData(response.data);
+            } catch (err: unknown) {
+                const errorMessage = err instanceof AxiosError ? err.response?.data?.message || err.response?.data || err.message : 'Failed to load usage overview';
+                setError(errorMessage);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void fetchUsage();
+    }, [range, token]);
+
+    const totalTokens = useMemo(() => {
+        if (!data) {
+            return 0;
+        }
+        return data.summary.total_input_tokens + data.summary.total_output_tokens + data.summary.total_cached_tokens;
+    }, [data]);
+
+    if (auth.loading) return null;
+
+    if (loading) {
+        return <div className="section-loading">Loading usage overview...</div>;
+    }
+
+    if (error) {
+        return <div className="section-error">{error}</div>;
+    }
+
+    if (!data || data.summary.session_count === 0) {
+        return (
+            <div className="section-empty">
+                <h3>No Usage Yet</h3>
+                <p>Estimated token usage appears here after chat sessions complete.</p>
+            </div>
+        );
+    }
+
+    return (
+        <section className="usage-section">
+            <div className="usage-header">
+                <div>
+                    <h2>Usage Dashboard</h2>
+                    <p className="usage-subtitle">
+                        Team-wide estimated usage based on session totals. Some activity may be missed.
+                    </p>
+                </div>
+                <div className="usage-range-picker" role="tablist" aria-label="Usage range">
+                    {RANGE_OPTIONS.map((option) => (
+                        <button
+                            key={option}
+                            type="button"
+                            className={`usage-range-btn ${range === option ? 'active' : ''}`}
+                            onClick={() => setRange(option)}
+                        >
+                            {option}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="usage-kpi-grid">
+                <article className="usage-kpi-card">
+                    <span className="usage-kpi-label">Estimated Cost</span>
+                    <strong>{formatUsd(data.summary.total_cost_usd)}</strong>
+                </article>
+                <article className="usage-kpi-card">
+                    <span className="usage-kpi-label">Total Tokens</span>
+                    <strong>{formatTokenCount(totalTokens)}</strong>
+                </article>
+                <article className="usage-kpi-card">
+                    <span className="usage-kpi-label">Input Tokens</span>
+                    <strong>{formatTokenCount(data.summary.total_input_tokens)}</strong>
+                </article>
+                <article className="usage-kpi-card">
+                    <span className="usage-kpi-label">Output Tokens</span>
+                    <strong>{formatTokenCount(data.summary.total_output_tokens)}</strong>
+                </article>
+                <article className="usage-kpi-card">
+                    <span className="usage-kpi-label">Cached Tokens</span>
+                    <strong>{formatTokenCount(data.summary.total_cached_tokens)}</strong>
+                </article>
+                <article className="usage-kpi-card">
+                    <span className="usage-kpi-label">Tracked Sessions</span>
+                    <strong>{formatTokenCount(data.summary.session_count)}</strong>
+                </article>
+            </div>
+
+            <div className="usage-chart-grid">
+                <article className="usage-chart-card">
+                    <div className="usage-chart-header">
+                        <h3>Estimated Cost Over Time</h3>
+                        <span>{formatUsd(data.summary.total_cost_usd)}</span>
+                    </div>
+                    <SimpleBars data={data.timeseries} valueKey="cost_usd" colorClass="cost" />
+                    <div className="usage-axis-labels">
+                        {data.timeseries.map((bucket) => (
+                            <span key={`cost-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, data.range)}</span>
+                        ))}
+                    </div>
+                </article>
+
+                <article className="usage-chart-card">
+                    <div className="usage-chart-header">
+                        <h3>Token Usage Over Time</h3>
+                        <span>{formatTokenCount(totalTokens)}</span>
+                    </div>
+                    <div className="usage-stacked-bars">
+                        {data.timeseries.map((bucket) => {
+                            const bucketTotal = bucket.input_tokens + bucket.output_tokens + bucket.cached_tokens;
+                            const inputHeight = bucketTotal === 0 ? 0 : (bucket.input_tokens / bucketTotal) * 100;
+                            const outputHeight = bucketTotal === 0 ? 0 : (bucket.output_tokens / bucketTotal) * 100;
+                            const cachedHeight = bucketTotal === 0 ? 0 : (bucket.cached_tokens / bucketTotal) * 100;
+                            return (
+                                <div key={`tokens-${bucket.bucket_start}`} className="usage-bar-column">
+                                    <div className="usage-stacked-bar">
+                                        <div className="usage-stacked-segment input" style={{ height: `${inputHeight}%` }} />
+                                        <div className="usage-stacked-segment output" style={{ height: `${outputHeight}%` }} />
+                                        <div className="usage-stacked-segment cached" style={{ height: `${cachedHeight}%` }} />
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                    <div className="usage-axis-labels">
+                        {data.timeseries.map((bucket) => (
+                            <span key={`token-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, data.range)}</span>
+                        ))}
+                    </div>
+                    <div className="usage-legend">
+                        <span><i className="input" />Input</span>
+                        <span><i className="output" />Output</span>
+                        <span><i className="cached" />Cached</span>
+                    </div>
+                </article>
+            </div>
+
+            <div className="usage-detail-grid">
+                <article className="usage-panel">
+                    <div className="usage-panel-header">
+                        <h3>Model Breakdown</h3>
+                    </div>
+                    <div className="usage-table-wrap">
+                        <table className="usage-table">
+                            <thead>
+                                <tr>
+                                    <th>Model</th>
+                                    <th>Sessions</th>
+                                    <th>Input</th>
+                                    <th>Output</th>
+                                    <th>Cached</th>
+                                    <th>Estimated Cost</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {data.models.map((model) => (
+                                    <tr key={model.model_id}>
+                                        <td>
+                                            <div className="usage-model-cell">
+                                                <strong>{model.model_id}</strong>
+                                                {!model.pricing_available ? <span>Pricing unavailable</span> : null}
+                                            </div>
+                                        </td>
+                                        <td>{formatTokenCount(model.session_count)}</td>
+                                        <td>{formatTokenCount(model.input_tokens)}</td>
+                                        <td>{formatTokenCount(model.output_tokens)}</td>
+                                        <td>{formatTokenCount(model.cached_tokens)}</td>
+                                        <td>{formatUsd(model.cost_usd)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </article>
+
+                <article className="usage-panel">
+                    <div className="usage-panel-header">
+                        <h3>Pricing</h3>
+                    </div>
+                    <div className="usage-pricing-list">
+                        {Object.entries(data.pricing).map(([modelId, pricingEntry]) => (
+                            <div key={modelId} className="usage-pricing-card">
+                                <strong>{modelId}</strong>
+                                <span>Input: {formatUsd(pricingEntry.input_per_million_usd)}/1M</span>
+                                <span>Cached: {formatUsd(pricingEntry.cached_input_per_million_usd)}/1M</span>
+                                <span>Output: {formatUsd(pricingEntry.output_per_million_usd)}/1M</span>
+                            </div>
+                        ))}
+                        {Object.keys(data.pricing).length === 0 ? (
+                            <p className="usage-pricing-empty">No hard-coded pricing matched the models in this range.</p>
+                        ) : null}
+                    </div>
+                </article>
+            </div>
+        </section>
+    );
+}

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { AxiosError } from 'axios';
 import { useAuth } from '../../lib/auth';
 import { axiosInstance } from '../../utils';
@@ -72,29 +72,92 @@ function formatBucketLabel(timestamp: number, range: UsageRange): string {
     return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
 }
 
-function SimpleBars({
-    data,
-    colorClass,
-    valueKey,
+function ChartScroller({
+    children,
+    points,
 }: {
-    data: UsageBucket[];
-    colorClass: string;
-    valueKey: 'cost_usd' | 'input_tokens' | 'output_tokens' | 'cached_tokens';
+    children: ReactNode;
+    points: number;
 }) {
-    const maxValue = Math.max(...data.map((item) => item[valueKey]), 0);
+    const minWidth = Math.max(360, points * 56);
+    return (
+        <div className="usage-chart-scroll">
+            <div className="usage-chart-scroll-inner" style={{ minWidth: `${minWidth}px` }}>
+                {children}
+            </div>
+        </div>
+    );
+}
+
+function CostBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) {
+    const maxValue = Math.max(...data.map((item) => item.cost_usd), 0);
+    const gridTemplateColumns = `repeat(${Math.max(data.length, 1)}, minmax(32px, 1fr))`;
+
+    if (maxValue === 0) {
+        return <div className="usage-chart-empty">No cost recorded in this time range.</div>;
+    }
 
     return (
-        <div className="usage-bars">
-            {data.map((item) => {
-                const value = item[valueKey];
-                const height = maxValue === 0 ? 6 : Math.max(6, (value / maxValue) * 100);
-                return (
-                    <div key={`${valueKey}-${item.bucket_start}`} className="usage-bar-column">
-                        <div className={`usage-bar ${colorClass}`} style={{ height: `${height}%` }} />
-                    </div>
-                );
-            })}
-        </div>
+        <ChartScroller points={data.length}>
+            <div className="usage-bars" style={{ gridTemplateColumns }}>
+                {data.map((item) => {
+                    const value = item.cost_usd;
+                    const height = (value / maxValue) * 100;
+                    return (
+                        <div key={`cost-${item.bucket_start}`} className="usage-bar-column">
+                            <div className="usage-bar-rail">
+                                <div className="usage-bar cost" style={{ height: `${height}%` }} />
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+            <div className="usage-axis-labels" style={{ gridTemplateColumns }}>
+                {data.map((bucket) => (
+                    <span key={`cost-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, range)}</span>
+                ))}
+            </div>
+        </ChartScroller>
+    );
+}
+
+function TokenBars({ data, range }: { data: UsageBucket[]; range: UsageRange }) {
+    const totals = data.map((bucket) => bucket.input_tokens + bucket.output_tokens + bucket.cached_tokens);
+    const maxTotal = Math.max(...totals, 0);
+    const gridTemplateColumns = `repeat(${Math.max(data.length, 1)}, minmax(32px, 1fr))`;
+
+    if (maxTotal === 0) {
+        return <div className="usage-chart-empty">No token activity recorded in this time range.</div>;
+    }
+
+    return (
+        <ChartScroller points={data.length}>
+            <div className="usage-bars" style={{ gridTemplateColumns }}>
+                {data.map((item) => {
+                    const bucketTotal = item.input_tokens + item.output_tokens + item.cached_tokens;
+                    const stackHeight = (bucketTotal / maxTotal) * 100;
+                    const inputHeight = bucketTotal === 0 ? 0 : (item.input_tokens / bucketTotal) * 100;
+                    const outputHeight = bucketTotal === 0 ? 0 : (item.output_tokens / bucketTotal) * 100;
+                    const cachedHeight = bucketTotal === 0 ? 0 : (item.cached_tokens / bucketTotal) * 100;
+                    return (
+                        <div key={`tokens-${item.bucket_start}`} className="usage-bar-column">
+                            <div className="usage-bar-rail">
+                                <div className="usage-stacked-bar" style={{ height: `${stackHeight}%` }}>
+                                    <div className="usage-stacked-segment input" style={{ height: `${inputHeight}%` }} />
+                                    <div className="usage-stacked-segment output" style={{ height: `${outputHeight}%` }} />
+                                    <div className="usage-stacked-segment cached" style={{ height: `${cachedHeight}%` }} />
+                                </div>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+            <div className="usage-axis-labels" style={{ gridTemplateColumns }}>
+                {data.map((bucket) => (
+                    <span key={`token-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, range)}</span>
+                ))}
+            </div>
+        </ChartScroller>
     );
 }
 
@@ -218,12 +281,7 @@ export default function UsageSection() {
                             <h3>Estimated Cost Over Time</h3>
                             <span>{formatUsd(data.summary.total_cost_usd)}</span>
                         </div>
-                        <SimpleBars data={data.timeseries} valueKey="cost_usd" colorClass="cost" />
-                        <div className="usage-axis-labels">
-                            {data.timeseries.map((bucket) => (
-                                <span key={`cost-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, data.range)}</span>
-                            ))}
-                        </div>
+                        <CostBars data={data.timeseries} range={data.range} />
                     </article>
                 ) : null}
 
@@ -232,28 +290,7 @@ export default function UsageSection() {
                         <h3>Token Usage Over Time</h3>
                         <span>{formatTokenCount(totalTokens)}</span>
                     </div>
-                    <div className="usage-stacked-bars">
-                        {data.timeseries.map((bucket) => {
-                            const bucketTotal = bucket.input_tokens + bucket.output_tokens + bucket.cached_tokens;
-                            const inputHeight = bucketTotal === 0 ? 0 : (bucket.input_tokens / bucketTotal) * 100;
-                            const outputHeight = bucketTotal === 0 ? 0 : (bucket.output_tokens / bucketTotal) * 100;
-                            const cachedHeight = bucketTotal === 0 ? 0 : (bucket.cached_tokens / bucketTotal) * 100;
-                            return (
-                                <div key={`tokens-${bucket.bucket_start}`} className="usage-bar-column">
-                                    <div className="usage-stacked-bar">
-                                        <div className="usage-stacked-segment input" style={{ height: `${inputHeight}%` }} />
-                                        <div className="usage-stacked-segment output" style={{ height: `${outputHeight}%` }} />
-                                        <div className="usage-stacked-segment cached" style={{ height: `${cachedHeight}%` }} />
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                    <div className="usage-axis-labels">
-                        {data.timeseries.map((bucket) => (
-                            <span key={`token-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, data.range)}</span>
-                        ))}
-                    </div>
+                    <TokenBars data={data.timeseries} range={data.range} />
                     <div className="usage-legend">
                         <span><i className="input" />Input</span>
                         <span><i className="output" />Output</span>

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -157,6 +157,8 @@ export default function UsageSection() {
         );
     }
 
+    const shouldHideCosting = totalTokens > 0 && data.summary.total_cost_usd === 0;
+
     return (
         <section className="usage-section">
             <div className="usage-header">
@@ -181,10 +183,12 @@ export default function UsageSection() {
             </div>
 
             <div className="usage-kpi-grid">
-                <article className="usage-kpi-card">
-                    <span className="usage-kpi-label">Estimated Cost</span>
-                    <strong>{formatUsd(data.summary.total_cost_usd)}</strong>
-                </article>
+                {!shouldHideCosting ? (
+                    <article className="usage-kpi-card">
+                        <span className="usage-kpi-label">Estimated Cost</span>
+                        <strong>{formatUsd(data.summary.total_cost_usd)}</strong>
+                    </article>
+                ) : null}
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Total Tokens</span>
                     <strong>{formatTokenCount(totalTokens)}</strong>
@@ -208,18 +212,20 @@ export default function UsageSection() {
             </div>
 
             <div className="usage-chart-grid">
-                <article className="usage-chart-card">
-                    <div className="usage-chart-header">
-                        <h3>Estimated Cost Over Time</h3>
-                        <span>{formatUsd(data.summary.total_cost_usd)}</span>
-                    </div>
-                    <SimpleBars data={data.timeseries} valueKey="cost_usd" colorClass="cost" />
-                    <div className="usage-axis-labels">
-                        {data.timeseries.map((bucket) => (
-                            <span key={`cost-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, data.range)}</span>
-                        ))}
-                    </div>
-                </article>
+                {!shouldHideCosting ? (
+                    <article className="usage-chart-card">
+                        <div className="usage-chart-header">
+                            <h3>Estimated Cost Over Time</h3>
+                            <span>{formatUsd(data.summary.total_cost_usd)}</span>
+                        </div>
+                        <SimpleBars data={data.timeseries} valueKey="cost_usd" colorClass="cost" />
+                        <div className="usage-axis-labels">
+                            {data.timeseries.map((bucket) => (
+                                <span key={`cost-label-${bucket.bucket_start}`}>{formatBucketLabel(bucket.bucket_start, data.range)}</span>
+                            ))}
+                        </div>
+                    </article>
+                ) : null}
 
                 <article className="usage-chart-card">
                     <div className="usage-chart-header">
@@ -270,7 +276,7 @@ export default function UsageSection() {
                                     <th>Input</th>
                                     <th>Output</th>
                                     <th>Cached</th>
-                                    <th>Estimated Cost</th>
+                                    {!shouldHideCosting ? <th>Estimated Cost</th> : null}
                                 </tr>
                             </thead>
                             <tbody>
@@ -286,7 +292,7 @@ export default function UsageSection() {
                                         <td>{formatTokenCount(model.input_tokens)}</td>
                                         <td>{formatTokenCount(model.output_tokens)}</td>
                                         <td>{formatTokenCount(model.cached_tokens)}</td>
-                                        <td>{formatUsd(model.cost_usd)}</td>
+                                        {!shouldHideCosting ? <td>{formatUsd(model.cost_usd)}</td> : null}
                                     </tr>
                                 ))}
                             </tbody>
@@ -294,24 +300,26 @@ export default function UsageSection() {
                     </div>
                 </article>
 
-                <article className="usage-panel">
-                    <div className="usage-panel-header">
-                        <h3>Pricing</h3>
-                    </div>
-                    <div className="usage-pricing-list">
-                        {Object.entries(data.pricing).map(([modelId, pricingEntry]) => (
-                            <div key={modelId} className="usage-pricing-card">
-                                <strong>{modelId}</strong>
-                                <span>Input: {formatUsd(pricingEntry.input_per_million_usd)}/1M</span>
-                                <span>Cached: {formatUsd(pricingEntry.cached_input_per_million_usd)}/1M</span>
-                                <span>Output: {formatUsd(pricingEntry.output_per_million_usd)}/1M</span>
-                            </div>
-                        ))}
-                        {Object.keys(data.pricing).length === 0 ? (
-                            <p className="usage-pricing-empty">No hard-coded pricing matched the models in this range.</p>
-                        ) : null}
-                    </div>
-                </article>
+                {!shouldHideCosting ? (
+                    <article className="usage-panel">
+                        <div className="usage-panel-header">
+                            <h3>Pricing</h3>
+                        </div>
+                        <div className="usage-pricing-list">
+                            {Object.entries(data.pricing).map(([modelId, pricingEntry]) => (
+                                <div key={modelId} className="usage-pricing-card">
+                                    <strong>{modelId}</strong>
+                                    <span>Input: {formatUsd(pricingEntry.input_per_million_usd)}/1M</span>
+                                    <span>Cached: {formatUsd(pricingEntry.cached_input_per_million_usd)}/1M</span>
+                                    <span>Output: {formatUsd(pricingEntry.output_per_million_usd)}/1M</span>
+                                </div>
+                            ))}
+                            {Object.keys(data.pricing).length === 0 ? (
+                                <p className="usage-pricing-empty">No hard-coded pricing matched the models in this range.</p>
+                            ) : null}
+                        </div>
+                    </article>
+                ) : null}
             </div>
         </section>
     );

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -319,17 +319,17 @@ export default function UsageSection() {
                             <tbody>
                                 {data.models.map((model) => (
                                     <tr key={model.model_id}>
-                                        <td>
+                                        <td data-label="Model">
                                             <div className="usage-model-cell">
                                                 <strong>{model.model_id}</strong>
                                                 {!model.pricing_available ? <span>Pricing unavailable</span> : null}
                                             </div>
                                         </td>
-                                        <td>{formatTokenCount(model.session_count)}</td>
-                                        <td>{formatTokenCount(model.input_tokens)}</td>
-                                        <td>{formatTokenCount(model.output_tokens)}</td>
-                                        <td>{formatTokenCount(model.cached_tokens)}</td>
-                                        {!shouldHideCosting ? <td>{formatUsd(model.cost_usd)}</td> : null}
+                                        <td data-label="Sessions">{formatTokenCount(model.session_count)}</td>
+                                        <td data-label="Input">{formatTokenCount(model.input_tokens)}</td>
+                                        <td data-label="Output">{formatTokenCount(model.output_tokens)}</td>
+                                        <td data-label="Cached">{formatTokenCount(model.cached_tokens)}</td>
+                                        {!shouldHideCosting ? <td data-label="Estimated Cost">{formatUsd(model.cost_usd)}</td> : null}
                                     </tr>
                                 ))}
                             </tbody>

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -204,7 +204,7 @@ export default function UsageSection() {
     if (auth.loading) return null;
 
     if (loading) {
-        return <div className="section-loading">Loading usage overview...</div>;
+        return null;
     }
 
     if (error) {

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -16,6 +16,7 @@ type UsageBucket = {
 };
 
 type ModelUsage = {
+    provider_id: string;
     model_id: string;
     input_tokens: number;
     output_tokens: number;
@@ -26,6 +27,7 @@ type ModelUsage = {
 };
 
 type PricingEntry = {
+    provider_id: string;
     input_per_million_usd: number;
     cached_input_per_million_usd: number;
     output_per_million_usd: number;
@@ -404,7 +406,7 @@ export default function UsageSection() {
                             <article key={model.model_id} className="usage-model-card">
                                 <div className="usage-model-card-header">
                                     <div className="usage-model-cell">
-                                        <strong>{model.model_id}</strong>
+                                        <strong>{`${model.provider_id}:${model.model_id}`}</strong>
                                         {!model.pricing_available ? <span>Pricing unavailable</span> : null}
                                     </div>
                                 </div>

--- a/frontend/src/components/dashboard/UsageSection.tsx
+++ b/frontend/src/components/dashboard/UsageSection.tsx
@@ -257,6 +257,7 @@ export default function UsageSection() {
         }
         return data.summary.total_input_tokens + data.summary.total_output_tokens + data.summary.total_cached_tokens;
     }, [data]);
+    const displayData = data;
 
     if (auth.loading) return null;
 
@@ -268,7 +269,7 @@ export default function UsageSection() {
         return <div className="section-error">{error}</div>;
     }
 
-    if (!data || data.summary.session_count === 0) {
+    if (!displayData || displayData.summary.session_count === 0) {
         return (
             <div className="section-empty">
                 <h3>No Usage Yet</h3>
@@ -277,9 +278,9 @@ export default function UsageSection() {
         );
     }
 
-    const shouldHideCosting = totalTokens > 0 && data.summary.total_cost_usd === 0;
-    const selectedCostBucket = data.timeseries.find((bucket) => bucket.bucket_start === selectedCostBucketStart) ?? data.timeseries.at(-1) ?? null;
-    const selectedTokenBucket = data.timeseries.find((bucket) => bucket.bucket_start === selectedTokenBucketStart) ?? data.timeseries.at(-1) ?? null;
+    const shouldHideCosting = totalTokens > 0 && displayData.summary.total_cost_usd === 0;
+    const selectedCostBucket = displayData.timeseries.find((bucket) => bucket.bucket_start === selectedCostBucketStart) ?? displayData.timeseries.at(-1) ?? null;
+    const selectedTokenBucket = displayData.timeseries.find((bucket) => bucket.bucket_start === selectedTokenBucketStart) ?? displayData.timeseries.at(-1) ?? null;
 
     return (
         <section className="usage-section">
@@ -313,7 +314,7 @@ export default function UsageSection() {
                             currency: 'USD',
                             minimumFractionDigits: 2,
                             maximumFractionDigits: 2,
-                        }).format(data.summary.total_cost_usd)}</strong>
+                        }).format(displayData.summary.total_cost_usd)}</strong>
                     </article>
                 ) : null}
                 <article className="usage-kpi-card">
@@ -322,19 +323,19 @@ export default function UsageSection() {
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Input Tokens</span>
-                    <strong>{formatKpiTokenCount(data.summary.total_input_tokens)}</strong>
+                    <strong>{formatKpiTokenCount(displayData.summary.total_input_tokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Output Tokens</span>
-                    <strong>{formatKpiTokenCount(data.summary.total_output_tokens)}</strong>
+                    <strong>{formatKpiTokenCount(displayData.summary.total_output_tokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Cached Tokens</span>
-                    <strong>{formatKpiTokenCount(data.summary.total_cached_tokens)}</strong>
+                    <strong>{formatKpiTokenCount(displayData.summary.total_cached_tokens)}</strong>
                 </article>
                 <article className="usage-kpi-card">
                     <span className="usage-kpi-label">Tracked Sessions</span>
-                    <strong>{formatKpiTokenCount(data.summary.session_count)}</strong>
+                    <strong>{formatKpiTokenCount(displayData.summary.session_count)}</strong>
                 </article>
             </div>
 
@@ -343,17 +344,17 @@ export default function UsageSection() {
                     <article className="usage-chart-card">
                         <div className="usage-chart-header">
                             <h3>Estimated Cost Over Time</h3>
-                            <span>{formatUsd(data.summary.total_cost_usd)}</span>
+                            <span>{formatUsd(displayData.summary.total_cost_usd)}</span>
                         </div>
                         <CostBars
-                            data={data.timeseries}
-                            range={data.range}
+                            data={displayData.timeseries}
+                            range={displayData.range}
                             selectedBucketStart={selectedCostBucket?.bucket_start ?? 0}
                             onSelectBucket={setSelectedCostBucketStart}
                         />
                         {selectedCostBucket ? (
                             <div className="usage-chart-selection">
-                                <strong>{formatBucketDateTime(selectedCostBucket.bucket_start, data.range)}</strong>
+                                <strong>{formatBucketDateTime(selectedCostBucket.bucket_start, displayData.range)}</strong>
                                 <div className="usage-chart-selection-grid">
                                     <span>Cost: {formatUsd(selectedCostBucket.cost_usd)}</span>
                                     <span>Sessions: {formatTokenCount(selectedCostBucket.session_count)}</span>
@@ -369,14 +370,14 @@ export default function UsageSection() {
                             <span>{formatTokenCount(totalTokens)}</span>
                         </div>
                     <TokenBars
-                        data={data.timeseries}
-                        range={data.range}
+                        data={displayData.timeseries}
+                        range={displayData.range}
                         selectedBucketStart={selectedTokenBucket?.bucket_start ?? 0}
                         onSelectBucket={setSelectedTokenBucketStart}
                     />
                     {selectedTokenBucket ? (
                         <div className="usage-chart-selection">
-                            <strong>{formatBucketDateTime(selectedTokenBucket.bucket_start, data.range)}</strong>
+                            <strong>{formatBucketDateTime(selectedTokenBucket.bucket_start, displayData.range)}</strong>
                             <div className="usage-chart-selection-grid">
                                 <span>Input: {formatTokenCount(selectedTokenBucket.input_tokens)}</span>
                                 <span>Output: {formatTokenCount(selectedTokenBucket.output_tokens)}</span>
@@ -398,36 +399,41 @@ export default function UsageSection() {
                     <div className="usage-panel-header">
                         <h3>Model Breakdown</h3>
                     </div>
-                    <div className="usage-table-wrap">
-                        <table className="usage-table">
-                            <thead>
-                                <tr>
-                                    <th>Model</th>
-                                    <th>Sessions</th>
-                                    <th>Input</th>
-                                    <th>Output</th>
-                                    <th>Cached</th>
-                                    {!shouldHideCosting ? <th>Estimated Cost</th> : null}
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {data.models.map((model) => (
-                                    <tr key={model.model_id}>
-                                        <td data-label="Model">
-                                            <div className="usage-model-cell">
-                                                <strong>{model.model_id}</strong>
-                                                {!model.pricing_available ? <span>Pricing unavailable</span> : null}
-                                            </div>
-                                        </td>
-                                        <td data-label="Sessions">{formatTokenCount(model.session_count)}</td>
-                                        <td data-label="Input">{formatTokenCount(model.input_tokens)}</td>
-                                        <td data-label="Output">{formatTokenCount(model.output_tokens)}</td>
-                                        <td data-label="Cached">{formatTokenCount(model.cached_tokens)}</td>
-                                        {!shouldHideCosting ? <td data-label="Estimated Cost">{formatUsd(model.cost_usd)}</td> : null}
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
+                    <div className="usage-model-list">
+                        {displayData.models.map((model) => (
+                            <article key={model.model_id} className="usage-model-card">
+                                <div className="usage-model-card-header">
+                                    <div className="usage-model-cell">
+                                        <strong>{model.model_id}</strong>
+                                        {!model.pricing_available ? <span>Pricing unavailable</span> : null}
+                                    </div>
+                                </div>
+                                <div className="usage-model-stats-grid">
+                                    <div className="usage-model-stat">
+                                        <span>Sessions</span>
+                                        <strong>{formatTokenCount(model.session_count)}</strong>
+                                    </div>
+                                    <div className="usage-model-stat">
+                                        <span>Input</span>
+                                        <strong>{formatTokenCount(model.input_tokens)}</strong>
+                                    </div>
+                                    <div className="usage-model-stat">
+                                        <span>Output</span>
+                                        <strong>{formatTokenCount(model.output_tokens)}</strong>
+                                    </div>
+                                    <div className="usage-model-stat">
+                                        <span>Cached</span>
+                                        <strong>{formatTokenCount(model.cached_tokens)}</strong>
+                                    </div>
+                                    {!shouldHideCosting ? (
+                                        <div className="usage-model-stat">
+                                            <span>Estimated Cost</span>
+                                            <strong>{formatUsd(model.cost_usd)}</strong>
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </article>
+                        ))}
                     </div>
                 </article>
 
@@ -437,7 +443,7 @@ export default function UsageSection() {
                             <h3>Pricing</h3>
                         </div>
                         <div className="usage-pricing-list">
-                            {Object.entries(data.pricing).map(([modelId, pricingEntry]) => (
+                            {Object.entries(displayData.pricing).map(([modelId, pricingEntry]) => (
                                 <div key={modelId} className="usage-pricing-card">
                                     <div className="usage-pricing-card-header">
                                         <strong>{modelId}</strong>
@@ -459,7 +465,7 @@ export default function UsageSection() {
                                     </div>
                                 </div>
                             ))}
-                            {Object.keys(data.pricing).length === 0 ? (
+                            {Object.keys(displayData.pricing).length === 0 ? (
                                 <p className="usage-pricing-empty">No hard-coded pricing matched the models in this range.</p>
                             ) : null}
                         </div>

--- a/frontend/src/components/dashboard/chat/Chat.css
+++ b/frontend/src/components/dashboard/chat/Chat.css
@@ -276,6 +276,15 @@
     color: #888;
 }
 
+.chat-usage-sync-warning {
+    padding: 0.7rem 1rem;
+    border-bottom: 1px solid rgba(245, 158, 11, 0.3);
+    background: rgba(245, 158, 11, 0.12);
+    color: #fbbf24;
+    font-size: 0.85rem;
+    line-height: 1.35;
+}
+
 .chat-workspace {
     flex: 1;
     min-height: 0;

--- a/frontend/src/components/dashboard/chat/ChatContainer.tsx
+++ b/frontend/src/components/dashboard/chat/ChatContainer.tsx
@@ -166,6 +166,7 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
     const [sessionDiffLoading, setSessionDiffLoading] = useState(false);
     const [sessionDiffError, setSessionDiffError] = useState<string | null>(null);
     const [expandedDiffPaths, setExpandedDiffPaths] = useState<string[]>([]);
+    const [usageSyncWarning, setUsageSyncWarning] = useState<string | null>(null);
     const draftMessagesBySessionIdRef = useRef<Record<string, string>>({});
     const [draftRevisionBySessionId, setDraftRevisionBySessionId] = useState<Record<string, number>>({});
     const [pendingPermissions, setPendingPermissions] = useState<PermissionRequest[]>([]);
@@ -221,6 +222,7 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
         setSessionDiffError(null);
         setSessionDiffLoading(false);
         setExpandedDiffPaths([]);
+        setUsageSyncWarning(null);
         setIsStreaming(false);
         completedAssistantMessageIdsRef.current = new Set();
         syncedUsageMessageIdsRef.current = new Set();
@@ -290,8 +292,11 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
                 {},
                 { headers: { Authorization: `Bearer ${token}` } }
             );
+            setUsageSyncWarning(null);
         } catch {
-            // Usage analytics are best-effort estimates.
+            const warningMessage = 'Failed to sync usage analytics. Usage totals may be stale until the next successful refresh.';
+            setUsageSyncWarning(warningMessage);
+            toast.error(warningMessage);
         }
     }, [token]);
 
@@ -1269,6 +1274,11 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
                         </span>
                     </div>
                 </div>
+                {usageSyncWarning ? (
+                    <div className="chat-usage-sync-warning" role="status">
+                        {usageSyncWarning}
+                    </div>
+                ) : null}
                 {activeSessionId ? (
                     <div className="chat-workspace without-diff">
                         <div className="chat-column chat-column-main">

--- a/frontend/src/components/dashboard/chat/ChatContainer.tsx
+++ b/frontend/src/components/dashboard/chat/ChatContainer.tsx
@@ -177,6 +177,7 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
     const abortControllerRef = useRef<AbortController | null>(null);
     const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null);
     const completedAssistantMessageIdsRef = useRef<Set<string>>(new Set());
+    const syncedUsageMessageIdsRef = useRef<Set<string>>(new Set());
     const lastEscapePressRef = useRef<number>(0);
     // const currentSessionInfoRef = useRef<{ id: string; isEmpty: boolean } | null>(null);
     const handledComposeKeyRef = useRef<string | null>(null);
@@ -222,6 +223,7 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
         setExpandedDiffPaths([]);
         setIsStreaming(false);
         completedAssistantMessageIdsRef.current = new Set();
+        syncedUsageMessageIdsRef.current = new Set();
     }, [abortSessionDataRequests]);
 
     const token = auth.loading ? null : auth.token;
@@ -277,6 +279,22 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
         }
     }, []);
 
+    const syncUsageForSession = useCallback(async (sessionId: string) => {
+        if (!token || sessionId === PENDING_SESSION_ID) {
+            return;
+        }
+
+        try {
+            await axiosInstance.post(
+                `/api/chat/sessions/${sessionId}/sync-usage`,
+                {},
+                { headers: { Authorization: `Bearer ${token}` } }
+            );
+        } catch {
+            // Usage analytics are best-effort estimates.
+        }
+    }, [token]);
+
     const handleSSEEvent = useCallback((event: SSEEvent) => {
         switch (event.type) {
             case 'message.updated': {
@@ -284,6 +302,14 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
                 if (info.role === 'assistant') {
                     if (info.time.completed) {
                         completedAssistantMessageIdsRef.current.add(info.id);
+                        if (
+                            activeSessionId
+                            && activeSessionId !== PENDING_SESSION_ID
+                            && !syncedUsageMessageIdsRef.current.has(info.id)
+                        ) {
+                            syncedUsageMessageIdsRef.current.add(info.id);
+                            void syncUsageForSession(activeSessionId);
+                        }
                     } else if (completedAssistantMessageIdsRef.current.has(info.id)) {
                         // Ignore stale out-of-order updates that regress a completed assistant message.
                         break;
@@ -398,7 +424,7 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
                 break;
             }
         }
-    }, [assertPermissionHasToolCall]);
+    }, [activeSessionId, assertPermissionHasToolCall, syncUsageForSession]);
 
     const startSSE = useCallback((sessionId: string) => {
         if (!token) return;
@@ -664,6 +690,10 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
                     .filter((message) => message.role === 'assistant' && Boolean(message.time.completed))
                     .map((message) => message.id)
             );
+            syncedUsageMessageIdsRef.current = new Set(completedAssistantMessageIdsRef.current);
+            if (loadedMessages.some((message) => message.role === 'assistant' && Boolean(message.time.completed))) {
+                void syncUsageForSession(sessionId);
+            }
             const isSessionBusy = sessionStatus === 'busy' || sessionStatus === 'retry';
             if (!isSessionBusy) {
                 setIsStreaming(false);
@@ -689,7 +719,7 @@ export default function ChatContainer({ initialDraftMessage, forceNewChat, onDra
                 messagesAbortControllerRef.current = null;
             }
         }
-    }, [token]);
+    }, [syncUsageForSession, token]);
 
     const loadPendingPermissions = useCallback(async (sessionId: string) => {
         if (!token) return;

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -27,6 +27,8 @@
   margin-bottom: -1px;
   transition: all 0.2s ease;
   border-radius: 8px 8px 0 0;
+  white-space: normal;
+  line-height: 1.15;
 }
 
 .tab-btn:hover {
@@ -109,7 +111,12 @@
     border-radius: 10px;
     margin-bottom: 0;
     padding: 0.7rem 0.4rem calc(0.7rem + env(safe-area-inset-bottom, 0px));
-    font-size: 0.9rem;
+    font-size: 0.76rem;
+    min-height: 3.35rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
   }
 
   .tab-btn.active {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,12 +5,14 @@ import WorkflowsSection from '../components/dashboard/WorkflowsSection';
 import RunHistorySection from '../components/dashboard/RunHistorySection';
 import AIModeSection from '../components/dashboard/AIModeSection';
 import SkillsSection from '../components/dashboard/SkillsSection';
+import UsageSection from '../components/dashboard/UsageSection';
 import './Home.css';
 
-type Tab = 'workflows' | 'history' | 'ai' | 'skills';
-const validTabs: Tab[] = ['ai', 'workflows', 'skills', 'history'];
+type Tab = 'workflows' | 'history' | 'ai' | 'skills' | 'usage';
+const validTabs: Tab[] = ['ai', 'usage', 'workflows', 'skills', 'history'];
 const tabTitles: Record<Tab, string> = {
     ai: 'AI Chat',
+    usage: 'Usage',
     workflows: 'Workflows',
     skills: 'Skills',
     history: 'Run History'
@@ -60,6 +62,8 @@ export default function Home() {
                 return <RunHistorySection />;
             case 'skills':
                 return <SkillsSection />;
+            case 'usage':
+                return <UsageSection />;
             case 'ai':
                 return (
                     <AIModeSection
@@ -79,6 +83,12 @@ export default function Home() {
                     onClick={() => setActiveTab('ai')}
                 >
                     AI chat
+                </button>
+                <button
+                    className={`tab-btn ${activeTab === 'usage' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('usage')}
+                >
+                    Usage
                 </button>
                 <button
                     className={`tab-btn ${activeTab === 'workflows' ? 'active' : ''}`}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -12,7 +12,7 @@ type Tab = 'workflows' | 'history' | 'ai' | 'skills' | 'usage';
 const validTabs: Tab[] = ['ai', 'usage', 'workflows', 'skills', 'history'];
 const tabTitles: Record<Tab, string> = {
     ai: 'AI Chat',
-    usage: 'Usage',
+    usage: 'Token Usage',
     workflows: 'Workflows',
     skills: 'Skills',
     history: 'Run History'
@@ -88,7 +88,7 @@ export default function Home() {
                     className={`tab-btn ${activeTab === 'usage' ? 'active' : ''}`}
                     onClick={() => setActiveTab('usage')}
                 >
-                    Usage
+                    Token Usage
                 </button>
                 <button
                     className={`tab-btn ${activeTab === 'workflows' ? 'active' : ''}`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "teamcopilot",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamcopilot",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A shared AI Agent for Teams",
   "homepage": "https://teamcopilot.ai",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "check:unused:functions": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
-    "check:unused:exports": "ts-prune -e -p tsconfig.json -i \"^src/types/shared/|^prisma/generated/|^src/index.ts:31 - createApp \\(used in module\\)$|^src/utils/secret-contract-validation.ts:45 - extractReferencedWorkflowSecrets \\(used in module\\)$|^src/utils/secret-contract-validation.ts:57 - extractReferencedSkillSecrets \\(used in module\\)$|^src/utils/secret-contract-validation.ts:158 - parseSkillRequiredSecrets \\(used in module\\)$\"",
+    "check:unused:exports": "ts-prune -e -p tsconfig.json -i \"^src/types/shared/|^prisma/generated/|^src/index.ts:[0-9]+ - createApp \\(used in module\\)$|^src/utils/secret-contract-validation.ts:45 - extractReferencedWorkflowSecrets \\(used in module\\)$|^src/utils/secret-contract-validation.ts:57 - extractReferencedSkillSecrets \\(used in module\\)$|^src/utils/secret-contract-validation.ts:158 - parseSkillRequiredSecrets \\(used in module\\)$\"",
     "check:unused": "npm run check:unused:functions && npm run check:unused:exports",
     "build": "npm run clean && npm run check:unused && cd frontend && npm run build && cd .. && prisma generate --schema prisma/schema.prisma && tsc && node scripts/copy-runtime-assets.mjs",
     "start": "node dist/index.js",

--- a/prisma/migrations/20260408073541_add_chat_session_usage/migration.sql
+++ b/prisma/migrations/20260408073541_add_chat_session_usage/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "chat_session_usage" (
+    "chat_session_id" TEXT NOT NULL PRIMARY KEY,
+    "input_tokens" INTEGER NOT NULL,
+    "output_tokens" INTEGER NOT NULL,
+    "cached_tokens" INTEGER NOT NULL,
+    "cost_usd" REAL NOT NULL,
+    "model_id" TEXT NOT NULL,
+    "updated_at" BIGINT NOT NULL,
+    CONSTRAINT "chat_session_usage_chat_session_id_fkey" FOREIGN KEY ("chat_session_id") REFERENCES "chat_sessions" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/migrations/20260409044955_add_last_synced_message_id_to_chat_session_usage/migration.sql
+++ b/prisma/migrations/20260409044955_add_last_synced_message_id_to_chat_session_usage/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "chat_session_usage" ADD COLUMN "last_synced_message_id" TEXT;

--- a/prisma/migrations/20260409045848_add_provider_id_to_chat_session_usage/migration.sql
+++ b/prisma/migrations/20260409045848_add_provider_id_to_chat_session_usage/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "chat_session_usage" ADD COLUMN "provider_id" TEXT;

--- a/prisma/migrations/20260409051857_require_provider_and_last_synced_message_id_in_chat_session_usage/migration.sql
+++ b/prisma/migrations/20260409051857_require_provider_and_last_synced_message_id_in_chat_session_usage/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - Made the column `last_synced_message_id` on table `chat_session_usage` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `provider_id` on table `chat_session_usage` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_chat_session_usage" (
+    "chat_session_id" TEXT NOT NULL PRIMARY KEY,
+    "last_synced_message_id" TEXT NOT NULL,
+    "provider_id" TEXT NOT NULL,
+    "input_tokens" INTEGER NOT NULL,
+    "output_tokens" INTEGER NOT NULL,
+    "cached_tokens" INTEGER NOT NULL,
+    "cost_usd" REAL NOT NULL,
+    "model_id" TEXT NOT NULL,
+    "updated_at" BIGINT NOT NULL,
+    CONSTRAINT "chat_session_usage_chat_session_id_fkey" FOREIGN KEY ("chat_session_id") REFERENCES "chat_sessions" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_chat_session_usage" ("cached_tokens", "chat_session_id", "cost_usd", "input_tokens", "last_synced_message_id", "model_id", "output_tokens", "provider_id", "updated_at") SELECT "cached_tokens", "chat_session_id", "cost_usd", "input_tokens", "last_synced_message_id", "model_id", "output_tokens", "provider_id", "updated_at" FROM "chat_session_usage";
+DROP TABLE "chat_session_usage";
+ALTER TABLE "new_chat_session_usage" RENAME TO "chat_session_usage";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,14 +94,16 @@ model chat_sessions {
 }
 
 model chat_session_usage {
-  chat_session_id String @id
-  input_tokens    Int
-  output_tokens   Int
-  cached_tokens   Int
-  cost_usd        Float
-  model_id        String
-  updated_at      BigInt
-  session         chat_sessions @relation(fields: [chat_session_id], references: [id], onDelete: Cascade)
+  chat_session_id        String @id
+  last_synced_message_id String
+  provider_id            String
+  input_tokens           Int
+  output_tokens          Int
+  cached_tokens          Int
+  cost_usd               Float
+  model_id               String
+  updated_at             BigInt
+  session                chat_sessions @relation(fields: [chat_session_id], references: [id], onDelete: Cascade)
 }
 
 model chat_session_tracked_files {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,7 +89,19 @@ model chat_sessions {
   created_at          BigInt
   updated_at          BigInt
   trackedFiles        chat_session_tracked_files[]
+  usage               chat_session_usage?
   user                users                      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+}
+
+model chat_session_usage {
+  chat_session_id String @id
+  input_tokens    Int
+  output_tokens   Int
+  cached_tokens   Int
+  cost_usd        Float
+  model_id        String
+  updated_at      BigInt
+  session         chat_sessions @relation(fields: [chat_session_id], references: [id], onDelete: Cascade)
 }
 
 model chat_session_tracked_files {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -34,6 +34,7 @@ import {
     captureCurrentFileBaseline,
     normalizeWorkspaceRelativePath,
 } from "../utils/chat-session-file-diff";
+import { syncChatSessionUsage } from "../utils/chat-usage";
 
 const router = express.Router({ mergeParams: true });
 const USER_INSTRUCTIONS_FILENAME = "USER_INSTRUCTIONS.md";
@@ -1413,6 +1414,11 @@ router.get('/sessions/:id/events', apiHandler(async (req, res) => {
 
                             // Filter events to only include ones for this session
                             if (eventSessionId === session.opencode_session_id) {
+                                if (event.type === "session.idle") {
+                                    void syncChatSessionUsage(session.id, session.opencode_session_id).catch(() => {
+                                        // Usage analytics are best-effort estimates.
+                                    });
+                                }
                                 const sanitizedEvent = sanitizeEventForClient(event as Record<string, unknown>);
                                 res.write(`data: ${JSON.stringify(sanitizeForClient(sanitizedEvent))}\n\n`);
                             }

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -952,6 +952,27 @@ router.get('/sessions/:id/messages', apiHandler(async (req, res) => {
     });
 }, true));
 
+router.post('/sessions/:id/sync-usage', apiHandler(async (req, res) => {
+    const id = req.params.id as string;
+
+    const session = await prisma.chat_sessions.findFirst({
+        where: {
+            id,
+            user_id: req.userId!
+        }
+    });
+
+    if (!session) {
+        throw {
+            status: 404,
+            message: 'Session not found'
+        };
+    }
+
+    await syncChatSessionUsage(session.id, session.opencode_session_id);
+    res.json({ success: true });
+}, true));
+
 // POST /api/chat/sessions/:id/messages - Send message
 router.post('/sessions/:id/messages', apiHandler(async (req, res) => {
     const id = req.params.id as string;
@@ -1414,11 +1435,6 @@ router.get('/sessions/:id/events', apiHandler(async (req, res) => {
 
                             // Filter events to only include ones for this session
                             if (eventSessionId === session.opencode_session_id) {
-                                if (event.type === "session.idle") {
-                                    void syncChatSessionUsage(session.id, session.opencode_session_id).catch(() => {
-                                        // Usage analytics are best-effort estimates.
-                                    });
-                                }
                                 const sanitizedEvent = sanitizeEventForClient(event as Record<string, unknown>);
                                 res.write(`data: ${JSON.stringify(sanitizeForClient(sanitizedEvent))}\n\n`);
                             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import chatRouter from "./chat";
 import skillsRouter from "./skills";
 import usersRouter from "./users";
 import secretsRouter from "./secrets";
+import usageRouter from "./usage";
 import { startCronJobs } from "./cronjob";
 import { startOpencodeServer, stopOpencodeServer } from "./opencode-server";
 import path from 'path';
@@ -116,6 +117,7 @@ export function createApp(): express.Express {
     apiRouter.use('/skills', skillsRouter);
     apiRouter.use('/users', usersRouter);
     apiRouter.use('/secrets', secretsRouter);
+    apiRouter.use('/usage', usageRouter);
     apiRouter.use('/opencode-auth', opencodeAuthRouter);
 
     app.use('/api', apiRouter);

--- a/src/usage/index.ts
+++ b/src/usage/index.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import { apiHandler } from "../utils";
+import { buildUsageOverview } from "../utils/chat-usage";
+
+const router = express.Router({ mergeParams: true });
+
+router.get("/overview", apiHandler(async (req, res) => {
+    const overview = await buildUsageOverview(req.query.range);
+    res.json(overview);
+}, true));
+
+export default router;

--- a/src/utils/chat-usage.ts
+++ b/src/utils/chat-usage.ts
@@ -17,6 +17,7 @@ type OpencodeAssistantTokens = {
 
 type OpencodeUserMessageInfo = {
     role: "user";
+    id: string;
     time: {
         created: number;
     };
@@ -24,6 +25,7 @@ type OpencodeUserMessageInfo = {
 
 type OpencodeAssistantMessageInfo = {
     role: "assistant";
+    id: string;
     time: {
         created: number;
         completed?: number;
@@ -55,6 +57,7 @@ function assertSessionMessages(value: unknown): asserts value is OpencodeSession
 
         const time = info.time as Record<string, unknown>;
         assertNonNegativeNumber(time.created, `Session message at index ${index} time.created`);
+        assertCondition(typeof info.id === "string" && info.id.length > 0, `Session message at index ${index} is missing id`);
 
         if (info.role === "assistant") {
             assertCondition(typeof info.modelID === "string" && info.modelID.length > 0, `Assistant message at index ${index} is missing modelID`);
@@ -90,41 +93,65 @@ export async function syncChatSessionUsage(chatSessionId: string, opencodeSessio
 
     assertSessionMessages(result.data);
     const messages = result.data;
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cachedTokens = 0;
-    let latestAssistantTimestamp = -1;
-    let modelId = "unknown";
-    let hasAssistantMessage = false;
+    const existingUsage = await prisma.chat_session_usage.findUnique({
+        where: {
+            chat_session_id: chatSessionId,
+        }
+    });
 
-    for (const message of messages) {
+    let startIndex = 0;
+    if (existingUsage) {
+        const lastSyncedIndex = messages.findIndex((message) => (
+            message.info.role === "assistant"
+            && message.info.id === existingUsage.last_synced_message_id
+        ));
+        if (lastSyncedIndex === -1) {
+            return;
+        }
+        startIndex = lastSyncedIndex + 1;
+    }
+
+    let deltaInputTokens = 0;
+    let deltaOutputTokens = 0;
+    let deltaCachedTokens = 0;
+    let latestProcessedAssistantMessageId: string | null = null;
+    let latestProcessedProviderId: string | null = null;
+    let latestProcessedModelId: string | null = null;
+
+    for (const message of messages.slice(startIndex)) {
         const info = message.info;
         if (info.role !== "assistant") {
             continue;
         }
 
-        hasAssistantMessage = true;
-        inputTokens += info.tokens.input;
-        outputTokens += info.tokens.output;
-        cachedTokens += info.tokens.cache.read;
-
-        const timestamp = info.time.completed ?? info.time.created;
-        if (timestamp >= latestAssistantTimestamp) {
-            latestAssistantTimestamp = timestamp;
-            modelId = info.modelID;
-        }
+        deltaInputTokens += info.tokens.input;
+        deltaOutputTokens += info.tokens.output;
+        deltaCachedTokens += info.tokens.cache.read;
+        latestProcessedAssistantMessageId = info.id;
+        latestProcessedProviderId = info.providerID;
+        latestProcessedModelId = info.modelID;
     }
 
-    if (!hasAssistantMessage) {
+    if (
+        latestProcessedAssistantMessageId === null
+        || latestProcessedProviderId === null
+        || latestProcessedModelId === null
+    ) {
         return;
     }
 
-    const costUsd = calculateEstimatedCostUsd({
-        modelId,
-        inputTokens,
-        outputTokens,
-        cachedTokens,
+    const deltaCostUsd = calculateEstimatedCostUsd({
+        providerId: latestProcessedProviderId,
+        modelId: latestProcessedModelId,
+        inputTokens: deltaInputTokens,
+        outputTokens: deltaOutputTokens,
+        cachedTokens: deltaCachedTokens,
     });
+
+    const nextInputTokens = (existingUsage?.input_tokens ?? 0) + deltaInputTokens;
+    const nextOutputTokens = (existingUsage?.output_tokens ?? 0) + deltaOutputTokens;
+    const nextCachedTokens = (existingUsage?.cached_tokens ?? 0) + deltaCachedTokens;
+    const nextCostUsd = (existingUsage?.cost_usd ?? 0) + deltaCostUsd;
 
     await prisma.chat_session_usage.upsert({
         where: {
@@ -132,19 +159,23 @@ export async function syncChatSessionUsage(chatSessionId: string, opencodeSessio
         },
         create: {
             chat_session_id: chatSessionId,
-            input_tokens: inputTokens,
-            output_tokens: outputTokens,
-            cached_tokens: cachedTokens,
-            cost_usd: costUsd,
-            model_id: modelId,
+            last_synced_message_id: latestProcessedAssistantMessageId,
+            provider_id: latestProcessedProviderId,
+            input_tokens: nextInputTokens,
+            output_tokens: nextOutputTokens,
+            cached_tokens: nextCachedTokens,
+            cost_usd: nextCostUsd,
+            model_id: latestProcessedModelId,
             updated_at: BigInt(Date.now()),
         },
         update: {
-            input_tokens: inputTokens,
-            output_tokens: outputTokens,
-            cached_tokens: cachedTokens,
-            cost_usd: costUsd,
-            model_id: modelId,
+            last_synced_message_id: latestProcessedAssistantMessageId,
+            provider_id: latestProcessedProviderId,
+            input_tokens: nextInputTokens,
+            output_tokens: nextOutputTokens,
+            cached_tokens: nextCachedTokens,
+            cost_usd: nextCostUsd,
+            model_id: latestProcessedModelId,
             updated_at: BigInt(Date.now()),
         }
     });
@@ -211,6 +242,7 @@ export async function buildUsageOverview(rawRange: unknown) {
 
     const bucketMap = new Map<number, UsageBucket>();
     const modelMap = new Map<string, {
+        provider_id: string;
         model_id: string;
         input_tokens: number;
         output_tokens: number;
@@ -244,21 +276,23 @@ export async function buildUsageOverview(rawRange: unknown) {
         bucket.session_count += 1;
         bucketMap.set(bucketStart, bucket);
 
-        const model = modelMap.get(row.model_id) ?? {
+        const modelKey = `${row.provider_id}:${row.model_id}`;
+        const model = modelMap.get(modelKey) ?? {
+            provider_id: row.provider_id,
             model_id: row.model_id,
             input_tokens: 0,
             output_tokens: 0,
             cached_tokens: 0,
             cost_usd: 0,
             session_count: 0,
-            pricing_available: getModelPricing(row.model_id) !== null,
+            pricing_available: getModelPricing(row.provider_id, row.model_id) !== null,
         };
         model.input_tokens += row.input_tokens;
         model.output_tokens += row.output_tokens;
         model.cached_tokens += row.cached_tokens;
         model.cost_usd += row.cost_usd;
         model.session_count += 1;
-        modelMap.set(row.model_id, model);
+        modelMap.set(modelKey, model);
 
         totalInputTokens += row.input_tokens;
         totalOutputTokens += row.output_tokens;
@@ -282,16 +316,18 @@ export async function buildUsageOverview(rawRange: unknown) {
 
     const models = Array.from(modelMap.values()).sort((a, b) => b.cost_usd - a.cost_usd);
     const pricing: Record<string, {
+        provider_id: string;
         input_per_million_usd: number;
         cached_input_per_million_usd: number;
         output_per_million_usd: number;
     }> = {};
     for (const model of models) {
-        const modelPricing = getModelPricing(model.model_id);
+        const modelPricing = getModelPricing(model.provider_id, model.model_id);
         if (!modelPricing) {
             continue;
         }
-        pricing[model.model_id] = {
+        pricing[`${model.provider_id}:${model.model_id}`] = {
+            provider_id: model.provider_id,
             input_per_million_usd: modelPricing.inputPerMillionUsd,
             cached_input_per_million_usd: modelPricing.cachedInputPerMillionUsd,
             output_per_million_usd: modelPricing.outputPerMillionUsd,

--- a/src/utils/chat-usage.ts
+++ b/src/utils/chat-usage.ts
@@ -1,34 +1,81 @@
 import prisma from "../prisma/client";
+import { assertCondition } from "./assert";
 import { getOpencodeClient } from "./opencode-client";
 import { calculateEstimatedCostUsd, getModelPricing } from "./model-pricing";
 
-type AssistantTokens = {
-    input?: number;
-    output?: number;
-    cache?: {
-        read?: number;
+type OpencodeTokenCache = {
+    write: number;
+    read: number;
+};
+
+type OpencodeAssistantTokens = {
+    input: number;
+    output: number;
+    reasoning: number;
+    cache: OpencodeTokenCache;
+};
+
+type OpencodeUserMessageInfo = {
+    role: "user";
+    time: {
+        created: number;
     };
 };
 
-type AssistantMessageInfo = {
-    role?: string;
-    modelID?: string;
-    tokens?: AssistantTokens;
-    time?: {
-        created?: number;
+type OpencodeAssistantMessageInfo = {
+    role: "assistant";
+    time: {
+        created: number;
         completed?: number;
     };
+    modelID: string;
+    providerID: string;
+    tokens: OpencodeAssistantTokens;
 };
 
-type SessionMessageContainer = {
-    info?: AssistantMessageInfo;
+type OpencodeSessionMessage = {
+    info: OpencodeUserMessageInfo | OpencodeAssistantMessageInfo;
 };
 
-function asNonNegativeInt(value: unknown): number {
-    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-        return 0;
+function assertNonNegativeNumber(value: unknown, label: string): asserts value is number {
+    assertCondition(typeof value === "number" && Number.isFinite(value) && value >= 0, `${label} must be a non-negative number`);
+}
+
+function assertSessionMessages(value: unknown): asserts value is OpencodeSessionMessage[] {
+    assertCondition(Array.isArray(value), "Session messages response is not an array");
+
+    for (const [index, message] of value.entries()) {
+        assertCondition(message !== null && typeof message === "object", `Session message at index ${index} must be an object`);
+        const messageRecord = message as Record<string, unknown>;
+        assertCondition(messageRecord.info !== null && typeof messageRecord.info === "object", `Session message at index ${index} is missing info`);
+
+        const info = messageRecord.info as Record<string, unknown>;
+        assertCondition(info.role === "user" || info.role === "assistant", `Session message at index ${index} has invalid role`);
+        assertCondition(info.time !== null && typeof info.time === "object", `Session message at index ${index} is missing time`);
+
+        const time = info.time as Record<string, unknown>;
+        assertNonNegativeNumber(time.created, `Session message at index ${index} time.created`);
+
+        if (info.role === "assistant") {
+            assertCondition(typeof info.modelID === "string" && info.modelID.length > 0, `Assistant message at index ${index} is missing modelID`);
+            assertCondition(typeof info.providerID === "string" && info.providerID.length > 0, `Assistant message at index ${index} is missing providerID`);
+            assertCondition(info.tokens !== null && typeof info.tokens === "object", `Assistant message at index ${index} is missing tokens`);
+
+            const tokens = info.tokens as Record<string, unknown>;
+            assertNonNegativeNumber(tokens.input, `Assistant message at index ${index} tokens.input`);
+            assertNonNegativeNumber(tokens.output, `Assistant message at index ${index} tokens.output`);
+            assertNonNegativeNumber(tokens.reasoning, `Assistant message at index ${index} tokens.reasoning`);
+            assertCondition(tokens.cache !== null && typeof tokens.cache === "object", `Assistant message at index ${index} tokens.cache is missing`);
+
+            const cache = tokens.cache as Record<string, unknown>;
+            assertNonNegativeNumber(cache.read, `Assistant message at index ${index} tokens.cache.read`);
+            assertNonNegativeNumber(cache.write, `Assistant message at index ${index} tokens.cache.write`);
+
+            if (time.completed !== undefined) {
+                assertNonNegativeNumber(time.completed, `Assistant message at index ${index} time.completed`);
+            }
+        }
     }
-    return Math.floor(value);
 }
 
 export async function syncChatSessionUsage(chatSessionId: string, opencodeSessionId: string): Promise<void> {
@@ -41,7 +88,8 @@ export async function syncChatSessionUsage(chatSessionId: string, opencodeSessio
         throw new Error("Failed to load session messages for usage sync");
     }
 
-    const messages = Array.isArray(result.data) ? result.data as SessionMessageContainer[] : [];
+    assertSessionMessages(result.data);
+    const messages = result.data;
     let inputTokens = 0;
     let outputTokens = 0;
     let cachedTokens = 0;
@@ -51,21 +99,19 @@ export async function syncChatSessionUsage(chatSessionId: string, opencodeSessio
 
     for (const message of messages) {
         const info = message.info;
-        if (info?.role !== "assistant") {
+        if (info.role !== "assistant") {
             continue;
         }
 
         hasAssistantMessage = true;
-        inputTokens += asNonNegativeInt(info.tokens?.input);
-        outputTokens += asNonNegativeInt(info.tokens?.output);
-        cachedTokens += asNonNegativeInt(info.tokens?.cache?.read);
+        inputTokens += info.tokens.input;
+        outputTokens += info.tokens.output;
+        cachedTokens += info.tokens.cache.read;
 
-        const timestamp = asNonNegativeInt(info.time?.completed) || asNonNegativeInt(info.time?.created);
+        const timestamp = info.time.completed ?? info.time.created;
         if (timestamp >= latestAssistantTimestamp) {
             latestAssistantTimestamp = timestamp;
-            modelId = typeof info.modelID === "string" && info.modelID.length > 0
-                ? info.modelID
-                : "unknown";
+            modelId = info.modelID;
         }
     }
 

--- a/src/utils/chat-usage.ts
+++ b/src/utils/chat-usage.ts
@@ -1,0 +1,264 @@
+import prisma from "../prisma/client";
+import { getOpencodeClient } from "./opencode-client";
+import { calculateEstimatedCostUsd, getModelPricing } from "./model-pricing";
+
+type AssistantTokens = {
+    input?: number;
+    output?: number;
+    cache?: {
+        read?: number;
+    };
+};
+
+type AssistantMessage = {
+    role?: string;
+    modelID?: string;
+    tokens?: AssistantTokens;
+    time?: {
+        created?: number;
+        completed?: number;
+    };
+};
+
+function asNonNegativeInt(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+        return 0;
+    }
+    return Math.floor(value);
+}
+
+export async function syncChatSessionUsage(chatSessionId: string, opencodeSessionId: string): Promise<void> {
+    const client = await getOpencodeClient();
+    const result = await client.session.messages({
+        path: { id: opencodeSessionId }
+    });
+
+    if (result.error) {
+        throw new Error("Failed to load session messages for usage sync");
+    }
+
+    const messages = Array.isArray(result.data) ? result.data as AssistantMessage[] : [];
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cachedTokens = 0;
+    let latestAssistantTimestamp = -1;
+    let modelId = "unknown";
+    let hasAssistantMessage = false;
+
+    for (const message of messages) {
+        if (message.role !== "assistant") {
+            continue;
+        }
+
+        hasAssistantMessage = true;
+        inputTokens += asNonNegativeInt(message.tokens?.input);
+        outputTokens += asNonNegativeInt(message.tokens?.output);
+        cachedTokens += asNonNegativeInt(message.tokens?.cache?.read);
+
+        const timestamp = asNonNegativeInt(message.time?.completed) || asNonNegativeInt(message.time?.created);
+        if (timestamp >= latestAssistantTimestamp) {
+            latestAssistantTimestamp = timestamp;
+            modelId = typeof message.modelID === "string" && message.modelID.length > 0
+                ? message.modelID
+                : "unknown";
+        }
+    }
+
+    if (!hasAssistantMessage) {
+        return;
+    }
+
+    const costUsd = calculateEstimatedCostUsd({
+        modelId,
+        inputTokens,
+        outputTokens,
+        cachedTokens,
+    });
+
+    await prisma.chat_session_usage.upsert({
+        where: {
+            chat_session_id: chatSessionId,
+        },
+        create: {
+            chat_session_id: chatSessionId,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            cached_tokens: cachedTokens,
+            cost_usd: costUsd,
+            model_id: modelId,
+            updated_at: BigInt(Date.now()),
+        },
+        update: {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            cached_tokens: cachedTokens,
+            cost_usd: costUsd,
+            model_id: modelId,
+            updated_at: BigInt(Date.now()),
+        }
+    });
+}
+
+type UsageRange = "24h" | "7d" | "30d" | "90d";
+
+type UsageBucket = {
+    bucket_start: number;
+    input_tokens: number;
+    output_tokens: number;
+    cached_tokens: number;
+    cost_usd: number;
+    session_count: number;
+};
+
+function getRangeConfig(range: UsageRange): { bucketMs: number; windowMs: number } {
+    switch (range) {
+        case "24h":
+            return { bucketMs: 60 * 60 * 1000, windowMs: 24 * 60 * 60 * 1000 };
+        case "7d":
+            return { bucketMs: 24 * 60 * 60 * 1000, windowMs: 7 * 24 * 60 * 60 * 1000 };
+        case "30d":
+            return { bucketMs: 24 * 60 * 60 * 1000, windowMs: 30 * 24 * 60 * 60 * 1000 };
+        case "90d":
+            return { bucketMs: 24 * 60 * 60 * 1000, windowMs: 90 * 24 * 60 * 60 * 1000 };
+    }
+}
+
+function normalizeUsageRange(value: unknown): UsageRange {
+    if (value === "24h" || value === "7d" || value === "30d" || value === "90d") {
+        return value;
+    }
+    return "7d";
+}
+
+function getBucketStart(timestamp: number, bucketMs: number): number {
+    return Math.floor(timestamp / bucketMs) * bucketMs;
+}
+
+export async function buildUsageOverview(rawRange: unknown) {
+    const range = normalizeUsageRange(rawRange);
+    const { bucketMs, windowMs } = getRangeConfig(range);
+    const now = Date.now();
+    const rangeStart = now - windowMs;
+
+    const usageRows = await prisma.chat_session_usage.findMany({
+        where: {
+            session: {
+                updated_at: {
+                    gte: BigInt(rangeStart),
+                    lte: BigInt(now),
+                }
+            }
+        },
+        include: {
+            session: {
+                select: {
+                    updated_at: true,
+                }
+            }
+        }
+    });
+
+    const bucketMap = new Map<number, UsageBucket>();
+    const modelMap = new Map<string, {
+        model_id: string;
+        input_tokens: number;
+        output_tokens: number;
+        cached_tokens: number;
+        cost_usd: number;
+        session_count: number;
+        pricing_available: boolean;
+    }>();
+
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalCachedTokens = 0;
+    let totalCostUsd = 0;
+
+    for (const row of usageRows) {
+        const sessionUpdatedAt = Number(row.session.updated_at);
+        const bucketStart = getBucketStart(sessionUpdatedAt, bucketMs);
+        const bucket = bucketMap.get(bucketStart) ?? {
+            bucket_start: bucketStart,
+            input_tokens: 0,
+            output_tokens: 0,
+            cached_tokens: 0,
+            cost_usd: 0,
+            session_count: 0,
+        };
+
+        bucket.input_tokens += row.input_tokens;
+        bucket.output_tokens += row.output_tokens;
+        bucket.cached_tokens += row.cached_tokens;
+        bucket.cost_usd += row.cost_usd;
+        bucket.session_count += 1;
+        bucketMap.set(bucketStart, bucket);
+
+        const model = modelMap.get(row.model_id) ?? {
+            model_id: row.model_id,
+            input_tokens: 0,
+            output_tokens: 0,
+            cached_tokens: 0,
+            cost_usd: 0,
+            session_count: 0,
+            pricing_available: getModelPricing(row.model_id) !== null,
+        };
+        model.input_tokens += row.input_tokens;
+        model.output_tokens += row.output_tokens;
+        model.cached_tokens += row.cached_tokens;
+        model.cost_usd += row.cost_usd;
+        model.session_count += 1;
+        modelMap.set(row.model_id, model);
+
+        totalInputTokens += row.input_tokens;
+        totalOutputTokens += row.output_tokens;
+        totalCachedTokens += row.cached_tokens;
+        totalCostUsd += row.cost_usd;
+    }
+
+    const bucketStarts: number[] = [];
+    for (let time = getBucketStart(rangeStart, bucketMs); time <= getBucketStart(now, bucketMs); time += bucketMs) {
+        bucketStarts.push(time);
+    }
+
+    const timeseries = bucketStarts.map((bucketStart) => bucketMap.get(bucketStart) ?? {
+        bucket_start: bucketStart,
+        input_tokens: 0,
+        output_tokens: 0,
+        cached_tokens: 0,
+        cost_usd: 0,
+        session_count: 0,
+    });
+
+    const models = Array.from(modelMap.values()).sort((a, b) => b.cost_usd - a.cost_usd);
+    const pricing: Record<string, {
+        input_per_million_usd: number;
+        cached_input_per_million_usd: number;
+        output_per_million_usd: number;
+    }> = {};
+    for (const model of models) {
+        const modelPricing = getModelPricing(model.model_id);
+        if (!modelPricing) {
+            continue;
+        }
+        pricing[model.model_id] = {
+            input_per_million_usd: modelPricing.inputPerMillionUsd,
+            cached_input_per_million_usd: modelPricing.cachedInputPerMillionUsd,
+            output_per_million_usd: modelPricing.outputPerMillionUsd,
+        };
+    }
+
+    return {
+        range,
+        estimated: true,
+        summary: {
+            total_input_tokens: totalInputTokens,
+            total_output_tokens: totalOutputTokens,
+            total_cached_tokens: totalCachedTokens,
+            total_cost_usd: totalCostUsd,
+            session_count: usageRows.length,
+        },
+        timeseries,
+        models,
+        pricing,
+    };
+}

--- a/src/utils/chat-usage.ts
+++ b/src/utils/chat-usage.ts
@@ -10,7 +10,7 @@ type AssistantTokens = {
     };
 };
 
-type AssistantMessage = {
+type AssistantMessageInfo = {
     role?: string;
     modelID?: string;
     tokens?: AssistantTokens;
@@ -18,6 +18,10 @@ type AssistantMessage = {
         created?: number;
         completed?: number;
     };
+};
+
+type SessionMessageContainer = {
+    info?: AssistantMessageInfo;
 };
 
 function asNonNegativeInt(value: unknown): number {
@@ -37,7 +41,7 @@ export async function syncChatSessionUsage(chatSessionId: string, opencodeSessio
         throw new Error("Failed to load session messages for usage sync");
     }
 
-    const messages = Array.isArray(result.data) ? result.data as AssistantMessage[] : [];
+    const messages = Array.isArray(result.data) ? result.data as SessionMessageContainer[] : [];
     let inputTokens = 0;
     let outputTokens = 0;
     let cachedTokens = 0;
@@ -46,20 +50,21 @@ export async function syncChatSessionUsage(chatSessionId: string, opencodeSessio
     let hasAssistantMessage = false;
 
     for (const message of messages) {
-        if (message.role !== "assistant") {
+        const info = message.info;
+        if (info?.role !== "assistant") {
             continue;
         }
 
         hasAssistantMessage = true;
-        inputTokens += asNonNegativeInt(message.tokens?.input);
-        outputTokens += asNonNegativeInt(message.tokens?.output);
-        cachedTokens += asNonNegativeInt(message.tokens?.cache?.read);
+        inputTokens += asNonNegativeInt(info.tokens?.input);
+        outputTokens += asNonNegativeInt(info.tokens?.output);
+        cachedTokens += asNonNegativeInt(info.tokens?.cache?.read);
 
-        const timestamp = asNonNegativeInt(message.time?.completed) || asNonNegativeInt(message.time?.created);
+        const timestamp = asNonNegativeInt(info.time?.completed) || asNonNegativeInt(info.time?.created);
         if (timestamp >= latestAssistantTimestamp) {
             latestAssistantTimestamp = timestamp;
-            modelId = typeof message.modelID === "string" && message.modelID.length > 0
-                ? message.modelID
+            modelId = typeof info.modelID === "string" && info.modelID.length > 0
+                ? info.modelID
                 : "unknown";
         }
     }

--- a/src/utils/model-pricing.ts
+++ b/src/utils/model-pricing.ts
@@ -4,25 +4,103 @@ type ModelPricing = {
     outputPerMillionUsd: number;
 };
 
-const MODEL_PRICING: Record<string, ModelPricing> = {
-    "gpt-5.3-codex": {
-        inputPerMillionUsd: 1.75,
-        cachedInputPerMillionUsd: 0.175,
-        outputPerMillionUsd: 14,
+const MODEL_PRICING: Record<string, Record<string, ModelPricing>> = {
+    openai: {
+        "gpt-5.4": {
+            inputPerMillionUsd: 2.5,
+            cachedInputPerMillionUsd: 0.25,
+            outputPerMillionUsd: 15,
+        },
+        "gpt-5.4-mini": {
+            inputPerMillionUsd: 0.75,
+            cachedInputPerMillionUsd: 0.075,
+            outputPerMillionUsd: 4.5,
+        },
+        "gpt-5.4-nano": {
+            inputPerMillionUsd: 0.2,
+            cachedInputPerMillionUsd: 0.02,
+            outputPerMillionUsd: 1.25,
+        },
+        "gpt-5.3-chat-latest": {
+            inputPerMillionUsd: 1.75,
+            cachedInputPerMillionUsd: 0.175,
+            outputPerMillionUsd: 14,
+        },
+        "gpt-5.3-codex": {
+            inputPerMillionUsd: 1.75,
+            cachedInputPerMillionUsd: 0.175,
+            outputPerMillionUsd: 14,
+        },
+        "gpt-5.1": {
+            inputPerMillionUsd: 1.25,
+            cachedInputPerMillionUsd: 0.125,
+            outputPerMillionUsd: 10,
+        },
+        "gpt-5": {
+            inputPerMillionUsd: 1.25,
+            cachedInputPerMillionUsd: 0.125,
+            outputPerMillionUsd: 10,
+        },
+        "gpt-5-mini": {
+            inputPerMillionUsd: 0.25,
+            cachedInputPerMillionUsd: 0.025,
+            outputPerMillionUsd: 2,
+        },
+        "gpt-5-nano": {
+            inputPerMillionUsd: 0.05,
+            cachedInputPerMillionUsd: 0.005,
+            outputPerMillionUsd: 0.4,
+        },
+        "gpt-4.1": {
+            inputPerMillionUsd: 2,
+            cachedInputPerMillionUsd: 0.5,
+            outputPerMillionUsd: 8,
+        },
+        "gpt-4.1-mini": {
+            inputPerMillionUsd: 0.4,
+            cachedInputPerMillionUsd: 0.1,
+            outputPerMillionUsd: 1.6,
+        },
+        "gpt-4.1-nano": {
+            inputPerMillionUsd: 0.1,
+            cachedInputPerMillionUsd: 0.025,
+            outputPerMillionUsd: 0.4,
+        },
+        "gpt-4o": {
+            inputPerMillionUsd: 2.5,
+            cachedInputPerMillionUsd: 1.25,
+            outputPerMillionUsd: 10,
+        },
+        "gpt-4o-mini": {
+            inputPerMillionUsd: 0.15,
+            cachedInputPerMillionUsd: 0.075,
+            outputPerMillionUsd: 0.6,
+        },
+        "o4-mini": {
+            inputPerMillionUsd: 1.1,
+            cachedInputPerMillionUsd: 0.275,
+            outputPerMillionUsd: 4.4,
+        },
+        "o3-mini": {
+            inputPerMillionUsd: 1.1,
+            cachedInputPerMillionUsd: 0.55,
+            outputPerMillionUsd: 4.4,
+        },
     },
 };
 
-export function getModelPricing(modelId: string): ModelPricing | null {
-    return MODEL_PRICING[modelId] ?? null;
+export function getModelPricing(providerId: string, modelId: string): ModelPricing | null {
+    return MODEL_PRICING[providerId]?.[modelId] ?? null;
 }
 
 export function calculateEstimatedCostUsd(args: {
+    providerId: string;
     modelId: string;
     inputTokens: number;
     outputTokens: number;
     cachedTokens: number;
 }): number {
-    const pricing = getModelPricing(args.modelId);
+    const pricing = getModelPricing(args.providerId, args.modelId);
     if (!pricing) {
         return 0;
     }

--- a/src/utils/model-pricing.ts
+++ b/src/utils/model-pricing.ts
@@ -89,7 +89,73 @@ const MODEL_PRICING: Record<string, Record<string, ModelPricing>> = {
     },
 };
 
+function assertNonNegativeNumber(value: unknown, label: string): asserts value is number {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+        throw new Error(`${label} must be a non-negative number`);
+    }
+}
+
+function parseOptionalNonNegativeNumber(raw: string | undefined, label: string): number | null {
+    if (raw === undefined || raw.length === 0) {
+        return null;
+    }
+
+    const parsed = Number(raw);
+    assertNonNegativeNumber(parsed, label);
+    return parsed;
+}
+
+function getPricingOverrideForConfiguredModel(providerId: string, modelId: string): ModelPricing | null {
+    const configuredModel = process.env.OPENCODE_MODEL;
+    if (!configuredModel) {
+        return null;
+    }
+
+    const [configuredProviderId, ...configuredModelParts] = configuredModel.split("/");
+    const configuredModelId = configuredModelParts.join("/");
+    if (!configuredProviderId || !configuredModelId) {
+        throw new Error("OPENCODE_MODEL must be in the format <provider>/<model>");
+    }
+
+    if (providerId !== configuredProviderId || modelId !== configuredModelId) {
+        return null;
+    }
+
+    const inputPerMillionUsd = parseOptionalNonNegativeNumber(
+        process.env.TEAMCOPILOT_MODEL_INPUT_PER_MILLION_USD,
+        "TEAMCOPILOT_MODEL_INPUT_PER_MILLION_USD"
+    );
+    const cachedInputPerMillionUsd = parseOptionalNonNegativeNumber(
+        process.env.TEAMCOPILOT_MODEL_CACHED_INPUT_PER_MILLION_USD,
+        "TEAMCOPILOT_MODEL_CACHED_INPUT_PER_MILLION_USD"
+    );
+    const outputPerMillionUsd = parseOptionalNonNegativeNumber(
+        process.env.TEAMCOPILOT_MODEL_OUTPUT_PER_MILLION_USD,
+        "TEAMCOPILOT_MODEL_OUTPUT_PER_MILLION_USD"
+    );
+
+    if (inputPerMillionUsd === null && cachedInputPerMillionUsd === null && outputPerMillionUsd === null) {
+        return null;
+    }
+
+    if (inputPerMillionUsd === null || cachedInputPerMillionUsd === null || outputPerMillionUsd === null) {
+        throw new Error(
+            "TEAMCOPILOT_MODEL_INPUT_PER_MILLION_USD, TEAMCOPILOT_MODEL_CACHED_INPUT_PER_MILLION_USD, and TEAMCOPILOT_MODEL_OUTPUT_PER_MILLION_USD must either all be set or all be unset"
+        );
+    }
+
+    return {
+        inputPerMillionUsd,
+        cachedInputPerMillionUsd,
+        outputPerMillionUsd,
+    };
+}
+
 export function getModelPricing(providerId: string, modelId: string): ModelPricing | null {
+    const override = getPricingOverrideForConfiguredModel(providerId, modelId);
+    if (override) {
+        return override;
+    }
     return MODEL_PRICING[providerId]?.[modelId] ?? null;
 }
 

--- a/src/utils/model-pricing.ts
+++ b/src/utils/model-pricing.ts
@@ -50,42 +50,7 @@ const MODEL_PRICING: Record<string, Record<string, ModelPricing>> = {
             inputPerMillionUsd: 0.05,
             cachedInputPerMillionUsd: 0.005,
             outputPerMillionUsd: 0.4,
-        },
-        "gpt-4.1": {
-            inputPerMillionUsd: 2,
-            cachedInputPerMillionUsd: 0.5,
-            outputPerMillionUsd: 8,
-        },
-        "gpt-4.1-mini": {
-            inputPerMillionUsd: 0.4,
-            cachedInputPerMillionUsd: 0.1,
-            outputPerMillionUsd: 1.6,
-        },
-        "gpt-4.1-nano": {
-            inputPerMillionUsd: 0.1,
-            cachedInputPerMillionUsd: 0.025,
-            outputPerMillionUsd: 0.4,
-        },
-        "gpt-4o": {
-            inputPerMillionUsd: 2.5,
-            cachedInputPerMillionUsd: 1.25,
-            outputPerMillionUsd: 10,
-        },
-        "gpt-4o-mini": {
-            inputPerMillionUsd: 0.15,
-            cachedInputPerMillionUsd: 0.075,
-            outputPerMillionUsd: 0.6,
-        },
-        "o4-mini": {
-            inputPerMillionUsd: 1.1,
-            cachedInputPerMillionUsd: 0.275,
-            outputPerMillionUsd: 4.4,
-        },
-        "o3-mini": {
-            inputPerMillionUsd: 1.1,
-            cachedInputPerMillionUsd: 0.55,
-            outputPerMillionUsd: 4.4,
-        },
+        }
     },
 };
 

--- a/src/utils/model-pricing.ts
+++ b/src/utils/model-pricing.ts
@@ -1,0 +1,35 @@
+type ModelPricing = {
+    inputPerMillionUsd: number;
+    cachedInputPerMillionUsd: number;
+    outputPerMillionUsd: number;
+};
+
+const MODEL_PRICING: Record<string, ModelPricing> = {
+    "gpt-5.3-codex": {
+        inputPerMillionUsd: 1.5,
+        cachedInputPerMillionUsd: 0.375,
+        outputPerMillionUsd: 6,
+    },
+};
+
+export function getModelPricing(modelId: string): ModelPricing | null {
+    return MODEL_PRICING[modelId] ?? null;
+}
+
+export function calculateEstimatedCostUsd(args: {
+    modelId: string;
+    inputTokens: number;
+    outputTokens: number;
+    cachedTokens: number;
+}): number {
+    const pricing = getModelPricing(args.modelId);
+    if (!pricing) {
+        return 0;
+    }
+
+    return (
+        (args.inputTokens * pricing.inputPerMillionUsd) / 1_000_000
+        + (args.cachedTokens * pricing.cachedInputPerMillionUsd) / 1_000_000
+        + (args.outputTokens * pricing.outputPerMillionUsd) / 1_000_000
+    );
+}

--- a/src/utils/model-pricing.ts
+++ b/src/utils/model-pricing.ts
@@ -71,10 +71,7 @@ function parseOptionalNonNegativeNumber(raw: string | undefined, label: string):
 }
 
 function getPricingOverrideForConfiguredModel(providerId: string, modelId: string): ModelPricing | null {
-    const configuredModel = process.env.OPENCODE_MODEL;
-    if (!configuredModel) {
-        return null;
-    }
+    const configuredModel = process.env.OPENCODE_MODEL!;
 
     const [configuredProviderId, ...configuredModelParts] = configuredModel.split("/");
     const configuredModelId = configuredModelParts.join("/");

--- a/src/utils/model-pricing.ts
+++ b/src/utils/model-pricing.ts
@@ -6,9 +6,9 @@ type ModelPricing = {
 
 const MODEL_PRICING: Record<string, ModelPricing> = {
     "gpt-5.3-codex": {
-        inputPerMillionUsd: 1.5,
-        cachedInputPerMillionUsd: 0.375,
-        outputPerMillionUsd: 6,
+        inputPerMillionUsd: 1.75,
+        cachedInputPerMillionUsd: 0.175,
+        outputPerMillionUsd: 14,
     },
 };
 

--- a/tests/usage-overview-route.test.ts
+++ b/tests/usage-overview-route.test.ts
@@ -89,6 +89,8 @@ async function main(): Promise<void> {
             data: [
                 {
                     chat_session_id: sessionOne.id,
+                    last_synced_message_id: "msg-session-one",
+                    provider_id: "openai",
                     input_tokens: 1000,
                     output_tokens: 300,
                     cached_tokens: 200,
@@ -98,6 +100,8 @@ async function main(): Promise<void> {
                 },
                 {
                     chat_session_id: sessionTwo.id,
+                    last_synced_message_id: "msg-session-two",
+                    provider_id: "azure-openai",
                     input_tokens: 400,
                     output_tokens: 100,
                     cached_tokens: 50,
@@ -107,6 +111,8 @@ async function main(): Promise<void> {
                 },
                 {
                     chat_session_id: oldSession.id,
+                    last_synced_message_id: "msg-old-session",
+                    provider_id: "openai",
                     input_tokens: 9999,
                     output_tokens: 999,
                     cached_tokens: 999,
@@ -133,8 +139,8 @@ async function main(): Promise<void> {
         assert.ok(Math.abs((response.body.summary.total_cost_usd as number) - 0.003375) < 1e-9);
         assert.ok(Array.isArray(response.body.timeseries));
         assert.ok(response.body.timeseries.length >= 7);
-        assert.ok(response.body.pricing["gpt-5.3-codex"]);
-        assert.equal(response.body.pricing["unknown-model"], undefined);
+        assert.ok(response.body.pricing["openai:gpt-5.3-codex"]);
+        assert.equal(response.body.pricing["azure-openai:unknown-model"], undefined);
 
         console.log("Usage overview route tests passed");
     } finally {

--- a/tests/usage-overview-route.test.ts
+++ b/tests/usage-overview-route.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import request from "supertest";
+
+async function main(): Promise<void> {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "teamcopilot-usage-route-"));
+    process.env.WORKSPACE_DIR = workspaceDir;
+
+    fs.mkdirSync(path.join(workspaceDir, ".agents", "skills"), { recursive: true });
+    fs.mkdirSync(path.join(workspaceDir, "workflows"), { recursive: true });
+
+    const prisma = require("../src/prisma/client").default as typeof import("../src/prisma/client").default;
+    const { ensureWorkspaceDatabase } = require("../src/utils/workspace-sync") as typeof import("../src/utils/workspace-sync");
+    const { loadJwtSecret } = require("../src/utils/jwt-secret") as typeof import("../src/utils/jwt-secret");
+    const { createApp } = require("../src/index") as typeof import("../src/index");
+
+    try {
+        await ensureWorkspaceDatabase();
+        await loadJwtSecret();
+
+        const now = BigInt(Date.now());
+        const oneDayMs = 24n * 60n * 60n * 1000n;
+
+        const viewer = await prisma.users.create({
+            data: {
+                email: `usage-viewer-${Date.now()}@example.com`,
+                name: "Usage Viewer",
+                role: "User",
+                created_at: now,
+                password_hash: "hashed-password",
+                must_change_password: false,
+            }
+        });
+
+        const otherUser = await prisma.users.create({
+            data: {
+                email: `usage-other-${Date.now()}@example.com`,
+                name: "Usage Other",
+                role: "User",
+                created_at: now,
+                password_hash: "hashed-password",
+                must_change_password: false,
+            }
+        });
+
+        const authSession = await prisma.chat_sessions.create({
+            data: {
+                user_id: viewer.id,
+                opencode_session_id: `usage-auth-${Date.now()}`,
+                title: "Usage auth session",
+                created_at: now,
+                updated_at: now,
+            }
+        });
+
+        const sessionOne = await prisma.chat_sessions.create({
+            data: {
+                user_id: viewer.id,
+                opencode_session_id: `usage-data-1-${Date.now()}`,
+                title: "Usage session one",
+                created_at: now - oneDayMs,
+                updated_at: now - oneDayMs,
+            }
+        });
+
+        const sessionTwo = await prisma.chat_sessions.create({
+            data: {
+                user_id: otherUser.id,
+                opencode_session_id: `usage-data-2-${Date.now()}`,
+                title: "Usage session two",
+                created_at: now,
+                updated_at: now,
+            }
+        });
+
+        const oldSession = await prisma.chat_sessions.create({
+            data: {
+                user_id: otherUser.id,
+                opencode_session_id: `usage-old-${Date.now()}`,
+                title: "Old usage session",
+                created_at: now - (120n * oneDayMs),
+                updated_at: now - (120n * oneDayMs),
+            }
+        });
+
+        await prisma.chat_session_usage.createMany({
+            data: [
+                {
+                    chat_session_id: sessionOne.id,
+                    input_tokens: 1000,
+                    output_tokens: 300,
+                    cached_tokens: 200,
+                    cost_usd: 0.003375,
+                    model_id: "gpt-5.3-codex",
+                    updated_at: now - oneDayMs,
+                },
+                {
+                    chat_session_id: sessionTwo.id,
+                    input_tokens: 400,
+                    output_tokens: 100,
+                    cached_tokens: 50,
+                    cost_usd: 0,
+                    model_id: "unknown-model",
+                    updated_at: now,
+                },
+                {
+                    chat_session_id: oldSession.id,
+                    input_tokens: 9999,
+                    output_tokens: 999,
+                    cached_tokens: 999,
+                    cost_usd: 9.99,
+                    model_id: "gpt-5.3-codex",
+                    updated_at: now - (120n * oneDayMs),
+                }
+            ]
+        });
+
+        const app = createApp();
+        const response = await request(app)
+            .get("/api/usage/overview")
+            .query({ range: "7d" })
+            .set("Authorization", `Bearer ${authSession.opencode_session_id}`)
+            .expect(200);
+
+        assert.equal(response.body.estimated, true);
+        assert.equal(response.body.summary.total_input_tokens, 1400);
+        assert.equal(response.body.summary.total_output_tokens, 400);
+        assert.equal(response.body.summary.total_cached_tokens, 250);
+        assert.equal(response.body.summary.session_count, 2);
+        assert.equal(response.body.models.length, 2);
+        assert.ok(Math.abs((response.body.summary.total_cost_usd as number) - 0.003375) < 1e-9);
+        assert.ok(Array.isArray(response.body.timeseries));
+        assert.ok(response.body.timeseries.length >= 7);
+        assert.ok(response.body.pricing["gpt-5.3-codex"]);
+        assert.equal(response.body.pricing["unknown-model"], undefined);
+
+        console.log("Usage overview route tests passed");
+    } finally {
+        await prisma.$disconnect();
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+}
+
+void main();


### PR DESCRIPTION
## Summary

- **New `chat_session_usage` table** — stores per-session token counts (input, output, cached), estimated cost, and model ID. Populated automatically when a chat session goes idle via the OpenCode SSE event stream.
- **Backend `/api/usage/overview` endpoint** — aggregates usage rows into time-bucketed timeseries (hourly for 24h, daily for 7d/30d/90d), per-model breakdowns, and summary KPIs. Includes hard-coded model pricing for cost estimation.
- **Frontend `UsageSection` component** — new "Usage" tab on the home dashboard showing KPI cards (estimated cost, total/input/output/cached tokens, session count), cost-over-time bar chart, stacked token-usage chart with legend, model breakdown table, and pricing reference cards. Supports 24h / 7d / 30d / 90d range switching.
- **Test coverage** — `tests/usage-overview-route.test.ts` validates the overview endpoint with multi-user sessions, model filtering, and 90-day-old data exclusion.

## Test plan

- [ ] Run `npx ts-node tests/usage-overview-route.test.ts` to verify the backend route test passes
- [ ] Start the dev server and open the "Usage" tab — confirm charts render with real or empty-state data
- [ ] Verify range picker (24h/7d/30d/90d) triggers a new fetch and updates the UI
- [ ] Confirm the old session (>90 days) is excluded from the 90d query

🤖 Generated with [Claude Code](https://claude.com/claude-code)