### PR TITLE
Add Google Vertex support to managed OpenCode auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ TEAMCOPILOT_PORT=5124
 OPENCODE_PORT=4096
 OPENCODE_MODEL=openai/gpt-5.3-codex
 # Azure OpenAI (optional): set AZURE_API_KEY, AZURE_OPENAI_ENDPOINT, OPENCODE_MODEL=azure-openai/<deployment>
-# Google Vertex Claude (only if picking this backend): required GOOGLE_CLOUD_PROJECT (or GCP_PROJECT / GCLOUD_PROJECT),
-#   GOOGLE_APPLICATION_CREDENTIALS (path to service account JSON), VERTEX_LOCATION, and OPENCODE_MODEL=google-vertex-anthropic/<vertex-model-id>.
+# Google Vertex via OpenCode (only if picking this backend): GOOGLE_CLOUD_PROJECT (or GCP_PROJECT / GCLOUD_PROJECT),
+#   GOOGLE_APPLICATION_CREDENTIALS (path to service account JSON), VERTEX_LOCATION, and OPENCODE_MODEL=<vertex-provider>/<model-id>
+#   where <vertex-provider> is google-vertex, google-vertex-anthropic, or another OpenCode google-vertex-* provider id.
 
 # Optional pricing overrides for the currently configured OPENCODE_MODEL.
 # Set all three or leave all three unset.

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ TEAMCOPILOT_PORT=5124
 OPENCODE_PORT=4096
 OPENCODE_MODEL=openai/gpt-5.3-codex
 # Azure OpenAI (optional): set AZURE_API_KEY, AZURE_OPENAI_ENDPOINT, OPENCODE_MODEL=azure-openai/<deployment>
-# Google Vertex Claude (optional): GOOGLE_CLOUD_PROJECT (or GCP_PROJECT / GCLOUD_PROJECT), optional GOOGLE_APPLICATION_CREDENTIALS,
-#   optional VERTEX_LOCATION (default global per OpenCode), OPENCODE_MODEL=google-vertex-anthropic/<vertex-model-id>
+# Google Vertex Claude (only if picking this backend): required GOOGLE_CLOUD_PROJECT (or GCP_PROJECT / GCLOUD_PROJECT),
+#   GOOGLE_APPLICATION_CREDENTIALS (path to service account JSON), VERTEX_LOCATION, and OPENCODE_MODEL=google-vertex-anthropic/<vertex-model-id>.
 
 # Optional pricing overrides for the currently configured OPENCODE_MODEL.
 # Set all three or leave all three unset.

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ TEAMCOPILOT_PORT=5124
 # Opencode Server Configuration
 OPENCODE_PORT=4096
 OPENCODE_MODEL=openai/gpt-5.3-codex
+# Azure OpenAI (optional): set AZURE_API_KEY, AZURE_OPENAI_ENDPOINT, OPENCODE_MODEL=azure-openai/<deployment>
+# Google Vertex Claude (optional): GOOGLE_CLOUD_PROJECT (or GCP_PROJECT / GCLOUD_PROJECT), optional GOOGLE_APPLICATION_CREDENTIALS,
+#   optional VERTEX_LOCATION (default global per OpenCode), OPENCODE_MODEL=google-vertex-anthropic/<vertex-model-id>
 
 # Optional pricing overrides for the currently configured OPENCODE_MODEL.
 # Set all three or leave all three unset.

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ TEAMCOPILOT_PORT=5124
 OPENCODE_PORT=4096
 OPENCODE_MODEL=openai/gpt-5.3-codex
 # Azure OpenAI (optional): set AZURE_API_KEY, AZURE_OPENAI_ENDPOINT, OPENCODE_MODEL=azure-openai/<deployment>
-# Google Vertex via OpenCode (only if picking this backend): GOOGLE_CLOUD_PROJECT (or GCP_PROJECT / GCLOUD_PROJECT),
+# Google Vertex via OpenCode (only if picking this backend): GOOGLE_CLOUD_PROJECT,
 #   GOOGLE_APPLICATION_CREDENTIALS (path to service account JSON), VERTEX_LOCATION, and OPENCODE_MODEL=<vertex-provider>/<model-id>
 #   where <vertex-provider> is google-vertex, google-vertex-anthropic, or another OpenCode google-vertex-* provider id.
 

--- a/frontend/src/pages/OpencodeAuthSetup.tsx
+++ b/frontend/src/pages/OpencodeAuthSetup.tsx
@@ -52,26 +52,55 @@ function isVisibleAuthMethod(method: ProviderAuthMethod, providerId: string): bo
     return !method.label.toLowerCase().includes('browser');
 }
 
-function getManagedEnvExamples(model: string): ManagedEnvExample[] {
-    const deployment = model.split('/').slice(1).join('/');
+function getManagedEnvExamples(providerId: string, model: string): ManagedEnvExample[] {
+    const modelSuffix = model.split('/').slice(1).join('/');
 
-    return [
-        {
-            key: 'AZURE_API_KEY',
-            value: 'abc123xyz',
-            help: 'API key for the Azure OpenAI resource.',
-        },
-        {
-            key: 'AZURE_OPENAI_ENDPOINT',
-            value: 'https://my-resource.openai.azure.com/',
-            help: 'Base endpoint for the Azure OpenAI resource.',
-        },
-        {
-            key: 'OPENCODE_MODEL',
-            value: `azure-openai/${deployment}`,
-            help: 'Provider id plus the Azure deployment name.',
-        },
-    ];
+    if (providerId === 'azure-openai') {
+        return [
+            {
+                key: 'AZURE_API_KEY',
+                value: 'abc123xyz',
+                help: 'API key for the Azure OpenAI resource.',
+            },
+            {
+                key: 'AZURE_OPENAI_ENDPOINT',
+                value: 'https://my-resource.openai.azure.com/',
+                help: 'Base endpoint for the Azure OpenAI resource.',
+            },
+            {
+                key: 'OPENCODE_MODEL',
+                value: `azure-openai/${modelSuffix}`,
+                help: 'Provider id plus the Azure deployment name.',
+            },
+        ];
+    }
+
+    if (providerId === 'google-vertex-anthropic') {
+        return [
+            {
+                key: 'GOOGLE_CLOUD_PROJECT',
+                value: 'my-gcp-project-id',
+                help: 'Google Cloud project ID. You may use GOOGLE_CLOUD_PROJECT, GCP_PROJECT, or GCLOUD_PROJECT.',
+            },
+            {
+                key: 'GOOGLE_APPLICATION_CREDENTIALS',
+                value: '/path/to/service-account.json',
+                help: 'Path to a service account JSON key (optional if using gcloud application-default login or GCE metadata).',
+            },
+            {
+                key: 'VERTEX_LOCATION',
+                value: 'global',
+                help: 'Vertex region (optional; OpenCode defaults to global).',
+            },
+            {
+                key: 'OPENCODE_MODEL',
+                value: `google-vertex-anthropic/${modelSuffix}`,
+                help: 'Provider id plus the Vertex Claude model ID (see OpenCode / Vertex model garden).',
+            },
+        ];
+    }
+
+    return [];
 }
 
 export default function OpencodeAuthSetup() {
@@ -114,8 +143,9 @@ export default function OpencodeAuthSetup() {
     const isManualCodeStep = oauthAuthorization?.method === 'code';
     const isAutoCodeStep = oauthAuthorization?.method === 'auto';
     const deviceCode = oauthAuthorization ? extractDeviceCode(oauthAuthorization.instructions) : '';
-    const isManagedProviderNotice = !isManualCodeStep && status?.provider_id === 'azure-openai';
-    const managedEnvExamples = status ? getManagedEnvExamples(status.model) : [];
+    const isManagedProviderNotice = !isManualCodeStep
+        && (status?.provider_id === 'azure-openai' || status?.provider_id === 'google-vertex-anthropic');
+    const managedEnvExamples = status ? getManagedEnvExamples(status.provider_id, status.model) : [];
 
     function resetOauthFlowState() {
         if (autoOauthRequestRef.current) {
@@ -378,13 +408,26 @@ export default function OpencodeAuthSetup() {
                                 </div>
                                 <div className="opencode-auth-managed-layout">
                                     <p className="opencode-auth-managed-intro">
-                                        Azure OpenAI is configured through service environment variables. To update this model,
-                                        ask the service administrator to change the values below and restart TeamCopilot.
+                                        {status.provider_id === 'azure-openai' ? (
+                                            <>
+                                                Azure OpenAI is configured through service environment variables. To update this model,
+                                                ask the service administrator to change the values below and restart TeamCopilot.
+                                            </>
+                                        ) : (
+                                            <>
+                                                Google Vertex (Claude) uses Application Default Credentials or a service account key.
+                                                To update this model, ask the service administrator to change the values below and restart TeamCopilot.
+                                            </>
+                                        )}
                                     </p>
                                     <div className="opencode-auth-managed-example-block">
                                         <div className="opencode-auth-managed-example-header">
                                             <h4>Required Values</h4>
-                                            <p>Use your Azure deployment name in <code>OPENCODE_MODEL</code></p>
+                                            <p>
+                                                {status.provider_id === 'azure-openai'
+                                                    ? 'Use your Azure deployment name in OPENCODE_MODEL'
+                                                    : 'Use your Vertex Claude model ID in OPENCODE_MODEL'}
+                                            </p>
                                         </div>
                                         <div className="opencode-auth-managed-example-list">
                                             {managedEnvExamples.map((example) => (

--- a/frontend/src/pages/OpencodeAuthSetup.tsx
+++ b/frontend/src/pages/OpencodeAuthSetup.tsx
@@ -85,12 +85,12 @@ function getManagedEnvExamples(providerId: string, model: string): ManagedEnvExa
             {
                 key: 'GOOGLE_APPLICATION_CREDENTIALS',
                 value: '/path/to/service-account.json',
-                help: 'Path to a service account JSON key (optional if using gcloud application-default login or GCE metadata).',
+                help: 'Path to a Google Cloud service account JSON key file (readable by this process).',
             },
             {
                 key: 'VERTEX_LOCATION',
                 value: 'global',
-                help: 'Vertex region (optional; OpenCode defaults to global).',
+                help: 'Vertex AI region or endpoint (for example global or us-central1). Must be set explicitly.',
             },
             {
                 key: 'OPENCODE_MODEL',
@@ -415,8 +415,9 @@ export default function OpencodeAuthSetup() {
                                             </>
                                         ) : (
                                             <>
-                                                Google Vertex (Claude) uses Application Default Credentials or a service account key.
-                                                To update this model, ask the service administrator to change the values below and restart TeamCopilot.
+                                                Google Vertex (Claude) requires GOOGLE_CLOUD_PROJECT, GOOGLE_APPLICATION_CREDENTIALS,
+                                                VERTEX_LOCATION, and OPENCODE_MODEL set in server environment variables. Ask the administrator
+                                                to update the values below and restart TeamCopilot.
                                             </>
                                         )}
                                     </p>

--- a/frontend/src/pages/OpencodeAuthSetup.tsx
+++ b/frontend/src/pages/OpencodeAuthSetup.tsx
@@ -85,7 +85,7 @@ function getManagedEnvExamples(providerId: string, model: string): ManagedEnvExa
             {
                 key: 'GOOGLE_CLOUD_PROJECT',
                 value: 'my-gcp-project-id',
-                help: 'Google Cloud project ID. You may use GOOGLE_CLOUD_PROJECT, GCP_PROJECT, or GCLOUD_PROJECT.',
+                help: 'Google Cloud project ID.',
             },
             {
                 key: 'GOOGLE_APPLICATION_CREDENTIALS',

--- a/frontend/src/pages/OpencodeAuthSetup.tsx
+++ b/frontend/src/pages/OpencodeAuthSetup.tsx
@@ -47,6 +47,11 @@ function isManagedGoogleVertexProvider(providerId: string): boolean {
     return id === 'google-vertex' || id.startsWith('google-vertex-');
 }
 
+/** Service-level (read-only) OpenCode providers — keep in sync with isServiceManagedProvider in src/utils/opencode-auth.ts */
+function isManagedServiceLevelProvider(providerId: string): boolean {
+    return providerId === 'azure-openai' || isManagedGoogleVertexProvider(providerId);
+}
+
 function isVisibleAuthMethod(method: ProviderAuthMethod, providerId: string): boolean {
     if (providerId === 'anthropic' && method.type === 'oauth') {
         return false;
@@ -149,7 +154,7 @@ export default function OpencodeAuthSetup() {
     const isAutoCodeStep = oauthAuthorization?.method === 'auto';
     const deviceCode = oauthAuthorization ? extractDeviceCode(oauthAuthorization.instructions) : '';
     const isManagedProviderNotice = !isManualCodeStep
-        && Boolean(status && (status.provider_id === 'azure-openai' || isManagedGoogleVertexProvider(status.provider_id)));
+        && Boolean(status && isManagedServiceLevelProvider(status.provider_id));
     const managedEnvExamples = status ? getManagedEnvExamples(status.provider_id, status.model) : [];
 
     function resetOauthFlowState() {
@@ -418,11 +423,17 @@ export default function OpencodeAuthSetup() {
                                                 Azure OpenAI is configured through service environment variables. To update this model,
                                                 ask the service administrator to change the values below and restart TeamCopilot.
                                             </>
-                                        ) : (
+                                        ) : isManagedGoogleVertexProvider(status.provider_id) ? (
                                             <>
                                                 Google Vertex requires GOOGLE_CLOUD_PROJECT, GOOGLE_APPLICATION_CREDENTIALS,
                                                 VERTEX_LOCATION, and OPENCODE_MODEL set in server environment variables. Ask the administrator
                                                 to update the values below and restart TeamCopilot.
+                                            </>
+                                        ) : (
+                                            <>
+                                                This provider is managed through service environment variables.
+                                                Ask the administrator which values to configure for{' '}
+                                                <code>{status.provider_id}</code> and restart TeamCopilot after they update the deployment.
                                             </>
                                         )}
                                     </p>
@@ -432,18 +443,26 @@ export default function OpencodeAuthSetup() {
                                             <p>
                                                 {status.provider_id === 'azure-openai'
                                                     ? 'Use your Azure deployment name in OPENCODE_MODEL'
-                                                    : 'Use your OpenCode Vertex model id in OPENCODE_MODEL'}
+                                                    : isManagedGoogleVertexProvider(status.provider_id)
+                                                        ? 'Use your OpenCode Vertex model id in OPENCODE_MODEL'
+                                                        : `Set OPENCODE_MODEL for provider ${status.provider_id} plus any required service env vars.`}
                                             </p>
                                         </div>
                                         <div className="opencode-auth-managed-example-list">
-                                            {managedEnvExamples.map((example) => (
-                                                <div key={example.key} className="opencode-auth-managed-example-row">
-                                                    <div className="opencode-auth-managed-example-copy">
-                                                        <code>{example.key}={example.value}</code>
+                                            {managedEnvExamples.length === 0 ? (
+                                                <p className="opencode-auth-help">
+                                                    No env examples are shown for this provider. Ask your administrator which variables apply.
+                                                </p>
+                                            ) : (
+                                                managedEnvExamples.map((example) => (
+                                                    <div key={example.key} className="opencode-auth-managed-example-row">
+                                                        <div className="opencode-auth-managed-example-copy">
+                                                            <code>{example.key}={example.value}</code>
+                                                        </div>
+                                                        <p>{example.help}</p>
                                                     </div>
-                                                    <p>{example.help}</p>
-                                                </div>
-                                            ))}
+                                                ))
+                                            )}
                                         </div>
                                     </div>
                                 </div>

--- a/frontend/src/pages/OpencodeAuthSetup.tsx
+++ b/frontend/src/pages/OpencodeAuthSetup.tsx
@@ -42,6 +42,11 @@ function extractDeviceCode(instructions: string): string {
     return match[1].trim();
 }
 
+function isManagedGoogleVertexProvider(providerId: string): boolean {
+    const id = providerId.toLowerCase();
+    return id === 'google-vertex' || id.startsWith('google-vertex-');
+}
+
 function isVisibleAuthMethod(method: ProviderAuthMethod, providerId: string): boolean {
     if (providerId === 'anthropic' && method.type === 'oauth') {
         return false;
@@ -75,7 +80,7 @@ function getManagedEnvExamples(providerId: string, model: string): ManagedEnvExa
         ];
     }
 
-    if (providerId === 'google-vertex-anthropic') {
+    if (isManagedGoogleVertexProvider(providerId)) {
         return [
             {
                 key: 'GOOGLE_CLOUD_PROJECT',
@@ -94,8 +99,8 @@ function getManagedEnvExamples(providerId: string, model: string): ManagedEnvExa
             },
             {
                 key: 'OPENCODE_MODEL',
-                value: `google-vertex-anthropic/${modelSuffix}`,
-                help: 'Provider id plus the Vertex Claude model ID (see OpenCode / Vertex model garden).',
+                value: model,
+                help: 'OpenCode Vertex provider prefix plus model id (for example google-vertex/... or google-vertex-anthropic/...).',
             },
         ];
     }
@@ -144,7 +149,7 @@ export default function OpencodeAuthSetup() {
     const isAutoCodeStep = oauthAuthorization?.method === 'auto';
     const deviceCode = oauthAuthorization ? extractDeviceCode(oauthAuthorization.instructions) : '';
     const isManagedProviderNotice = !isManualCodeStep
-        && (status?.provider_id === 'azure-openai' || status?.provider_id === 'google-vertex-anthropic');
+        && Boolean(status && (status.provider_id === 'azure-openai' || isManagedGoogleVertexProvider(status.provider_id)));
     const managedEnvExamples = status ? getManagedEnvExamples(status.provider_id, status.model) : [];
 
     function resetOauthFlowState() {
@@ -415,7 +420,7 @@ export default function OpencodeAuthSetup() {
                                             </>
                                         ) : (
                                             <>
-                                                Google Vertex (Claude) requires GOOGLE_CLOUD_PROJECT, GOOGLE_APPLICATION_CREDENTIALS,
+                                                Google Vertex requires GOOGLE_CLOUD_PROJECT, GOOGLE_APPLICATION_CREDENTIALS,
                                                 VERTEX_LOCATION, and OPENCODE_MODEL set in server environment variables. Ask the administrator
                                                 to update the values below and restart TeamCopilot.
                                             </>
@@ -427,7 +432,7 @@ export default function OpencodeAuthSetup() {
                                             <p>
                                                 {status.provider_id === 'azure-openai'
                                                     ? 'Use your Azure deployment name in OPENCODE_MODEL'
-                                                    : 'Use your Vertex Claude model ID in OPENCODE_MODEL'}
+                                                    : 'Use your OpenCode Vertex model id in OPENCODE_MODEL'}
                                             </p>
                                         </div>
                                         <div className="opencode-auth-managed-example-list">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamcopilot",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamcopilot",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamcopilot",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A shared AI Agent for Teams",
   "homepage": "https://teamcopilot.ai",
   "repository": {

--- a/src/utils/opencode-auth.ts
+++ b/src/utils/opencode-auth.ts
@@ -120,7 +120,7 @@ async function writeAuthRecord(filepath: string, data: AuthRecord): Promise<void
         mode: 0o600,
     });
     await fs.rename(tempPath, filepath);
-    await fs.chmod(filepath, 0o600).catch(() => {});
+    await fs.chmod(filepath, 0o600).catch(() => { });
 }
 
 async function readOpencodeConfig(filepath: string): Promise<OpencodeConfigRecord> {
@@ -150,7 +150,7 @@ async function writeOpencodeConfig(filepath: string, data: OpencodeConfigRecord)
         mode: 0o600,
     });
     await fs.rename(tempPath, filepath);
-    await fs.chmod(filepath, 0o600).catch(() => {});
+    await fs.chmod(filepath, 0o600).catch(() => { });
 }
 
 export function getConfiguredModelProviderId(): string {
@@ -215,8 +215,7 @@ function hasRequiredAzureEnvironment(): boolean {
 }
 
 function getGoogleCloudProjectFromEnv(): string | undefined {
-    const trimmed
-        = (process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCP_PROJECT ?? process.env.GCLOUD_PROJECT ?? "").trim();
+    const trimmed = (process.env.GOOGLE_CLOUD_PROJECT ?? "").trim();
     return isNonEmptyString(trimmed) ? trimmed : undefined;
 }
 
@@ -307,10 +306,8 @@ export async function setRuntimeProviderAuth(providerId: string, info: ProviderA
 }
 
 export async function syncManagedProviderConfiguration(): Promise<void> {
-    const projectFallback = process.env.GCP_PROJECT?.trim() ?? process.env.GCLOUD_PROJECT?.trim();
-    if (!isNonEmptyString(process.env.GOOGLE_CLOUD_PROJECT?.trim()) && isNonEmptyString(projectFallback)) {
-        process.env.GOOGLE_CLOUD_PROJECT = projectFallback;
-    }
+    // Azure OpenAI: workspace opencode.json must list the deployment, base URL, and @ai-sdk/azure options.
+    // Google Vertex providers are built into OpenCode; project/region/credentials come from process env only — no stanza needed here.
 
     const providerId = getConfiguredModelProviderId();
     if (!isAzureCustomProvider(providerId) || !hasRequiredAzureEnvironment()) {

--- a/src/utils/opencode-auth.ts
+++ b/src/utils/opencode-auth.ts
@@ -225,14 +225,18 @@ function hasRequiredVertexAnthropicProject(): boolean {
     return getGoogleCloudProjectFromEnv() !== undefined;
 }
 
-async function hasReadableGoogleApplicationCredentialsPath(): Promise<boolean> {
-    const credPathRaw = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-    if (credPathRaw === undefined || credPathRaw.trim().length === 0) {
-        return true;
+function hasVertexLocationConfigured(): boolean {
+    return isNonEmptyString(process.env.VERTEX_LOCATION?.trim());
+}
+
+async function googleApplicationCredentialsConfigured(): Promise<boolean> {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+    if (!credPath) {
+        return false;
     }
 
     try {
-        await fs.access(credPathRaw.trim(), fsConstants.R_OK);
+        await fs.access(credPath, fsConstants.R_OK);
         return true;
     } catch {
         return false;
@@ -248,12 +252,16 @@ async function hasVertexAnthropicManagedRuntimeReady(providerId: string): Promis
         return false;
     }
 
+    if (!hasVertexLocationConfigured()) {
+        return false;
+    }
+
     const modelTail = getConfiguredModelId().trim();
     if (!modelTail) {
         return false;
     }
 
-    return await hasReadableGoogleApplicationCredentialsPath();
+    return await googleApplicationCredentialsConfigured();
 }
 
 async function hasAzureProviderConfiguration(providerId: string): Promise<boolean> {

--- a/src/utils/opencode-auth.ts
+++ b/src/utils/opencode-auth.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises";
+import { constants as fsConstants } from "fs";
 import path from "path";
 import { assertEnv } from "./assert";
 import { getWorkspaceDirFromEnv } from "./workspace-sync";
+
+const VERTEX_ANTHROPIC_PROVIDER_ID = "google-vertex-anthropic";
 
 type ProviderAuthInfo =
     | {
@@ -195,8 +198,12 @@ function isAzureCustomProvider(providerId: string): boolean {
     return normalizeProviderId(providerId).toLowerCase() === "azure-openai";
 }
 
+function isGoogleVertexAnthropicManagedProvider(providerId: string): boolean {
+    return normalizeProviderId(providerId).toLowerCase() === VERTEX_ANTHROPIC_PROVIDER_ID;
+}
+
 export function isServiceManagedProvider(providerId: string): boolean {
-    return isAzureCustomProvider(providerId);
+    return isAzureCustomProvider(providerId) || isGoogleVertexAnthropicManagedProvider(providerId);
 }
 
 function normalizeAzureEndpoint(endpoint: string): string {
@@ -206,6 +213,47 @@ function normalizeAzureEndpoint(endpoint: string): string {
 function hasRequiredAzureEnvironment(): boolean {
     return isNonEmptyString(process.env.AZURE_API_KEY)
         && isNonEmptyString(process.env.AZURE_OPENAI_ENDPOINT);
+}
+
+function getGoogleCloudProjectFromEnv(): string | undefined {
+    const trimmed
+        = (process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCP_PROJECT ?? process.env.GCLOUD_PROJECT ?? "").trim();
+    return isNonEmptyString(trimmed) ? trimmed : undefined;
+}
+
+function hasRequiredVertexAnthropicProject(): boolean {
+    return getGoogleCloudProjectFromEnv() !== undefined;
+}
+
+async function hasReadableGoogleApplicationCredentialsPath(): Promise<boolean> {
+    const credPathRaw = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (credPathRaw === undefined || credPathRaw.trim().length === 0) {
+        return true;
+    }
+
+    try {
+        await fs.access(credPathRaw.trim(), fsConstants.R_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function hasVertexAnthropicManagedRuntimeReady(providerId: string): Promise<boolean> {
+    if (!isGoogleVertexAnthropicManagedProvider(providerId)) {
+        return false;
+    }
+
+    if (!hasRequiredVertexAnthropicProject()) {
+        return false;
+    }
+
+    const modelTail = getConfiguredModelId().trim();
+    if (!modelTail) {
+        return false;
+    }
+
+    return await hasReadableGoogleApplicationCredentialsPath();
 }
 
 async function hasAzureProviderConfiguration(providerId: string): Promise<boolean> {
@@ -230,6 +278,10 @@ export async function hasRuntimeProviderCredentials(providerId: string): Promise
         return hasRequiredAzureEnvironment() && await hasAzureProviderConfiguration(providerId);
     }
 
+    if (isGoogleVertexAnthropicManagedProvider(providerId)) {
+        return await hasVertexAnthropicManagedRuntimeReady(providerId);
+    }
+
     return Boolean(await getRuntimeProviderAuth(providerId));
 }
 
@@ -248,6 +300,11 @@ export async function setRuntimeProviderAuth(providerId: string, info: ProviderA
 }
 
 export async function syncManagedProviderConfiguration(): Promise<void> {
+    const projectFallback = process.env.GCP_PROJECT?.trim() ?? process.env.GCLOUD_PROJECT?.trim();
+    if (!isNonEmptyString(process.env.GOOGLE_CLOUD_PROJECT?.trim()) && isNonEmptyString(projectFallback)) {
+        process.env.GOOGLE_CLOUD_PROJECT = projectFallback;
+    }
+
     const providerId = getConfiguredModelProviderId();
     if (!isAzureCustomProvider(providerId) || !hasRequiredAzureEnvironment()) {
         return;

--- a/src/utils/opencode-auth.ts
+++ b/src/utils/opencode-auth.ts
@@ -201,6 +201,7 @@ function isAzureCustomProvider(providerId: string): boolean {
     return normalizeProviderId(providerId).toLowerCase() === "azure-openai";
 }
 
+/** Service-level credentials (TeamCopilot env, not per-user auth UI) — keep in sync with isManagedServiceLevelProvider in OpencodeAuthSetup.tsx */
 export function isServiceManagedProvider(providerId: string): boolean {
     return isAzureCustomProvider(providerId) || isGoogleVertexManagedProvider(providerId);
 }
@@ -219,8 +220,8 @@ function getGoogleCloudProjectFromEnv(): string | undefined {
     return isNonEmptyString(trimmed) ? trimmed : undefined;
 }
 
-function hasRequiredVertexManagedProject(): boolean {
-    return getGoogleCloudProjectFromEnv() !== undefined;
+async function hasRequiredVertexManagedProject(): Promise<boolean> {
+    return getGoogleCloudProjectFromEnv() !== undefined && hasVertexLocationConfigured() && await googleApplicationCredentialsConfigured();
 }
 
 function hasVertexLocationConfigured(): boolean {
@@ -246,11 +247,7 @@ async function hasVertexManagedRuntimeReady(providerId: string): Promise<boolean
         return false;
     }
 
-    if (!hasRequiredVertexManagedProject()) {
-        return false;
-    }
-
-    if (!hasVertexLocationConfigured()) {
+    if (!(await hasRequiredVertexManagedProject())) {
         return false;
     }
 
@@ -259,7 +256,7 @@ async function hasVertexManagedRuntimeReady(providerId: string): Promise<boolean
         return false;
     }
 
-    return await googleApplicationCredentialsConfigured();
+    return true;
 }
 
 async function hasAzureProviderConfiguration(providerId: string): Promise<boolean> {

--- a/src/utils/opencode-auth.ts
+++ b/src/utils/opencode-auth.ts
@@ -4,7 +4,10 @@ import path from "path";
 import { assertEnv } from "./assert";
 import { getWorkspaceDirFromEnv } from "./workspace-sync";
 
-const VERTEX_ANTHROPIC_PROVIDER_ID = "google-vertex-anthropic";
+function isGoogleVertexManagedProvider(providerId: string): boolean {
+    const id = normalizeProviderId(providerId).toLowerCase();
+    return id === "google-vertex" || id.startsWith("google-vertex-");
+}
 
 type ProviderAuthInfo =
     | {
@@ -198,12 +201,8 @@ function isAzureCustomProvider(providerId: string): boolean {
     return normalizeProviderId(providerId).toLowerCase() === "azure-openai";
 }
 
-function isGoogleVertexAnthropicManagedProvider(providerId: string): boolean {
-    return normalizeProviderId(providerId).toLowerCase() === VERTEX_ANTHROPIC_PROVIDER_ID;
-}
-
 export function isServiceManagedProvider(providerId: string): boolean {
-    return isAzureCustomProvider(providerId) || isGoogleVertexAnthropicManagedProvider(providerId);
+    return isAzureCustomProvider(providerId) || isGoogleVertexManagedProvider(providerId);
 }
 
 function normalizeAzureEndpoint(endpoint: string): string {
@@ -221,7 +220,7 @@ function getGoogleCloudProjectFromEnv(): string | undefined {
     return isNonEmptyString(trimmed) ? trimmed : undefined;
 }
 
-function hasRequiredVertexAnthropicProject(): boolean {
+function hasRequiredVertexManagedProject(): boolean {
     return getGoogleCloudProjectFromEnv() !== undefined;
 }
 
@@ -243,12 +242,12 @@ async function googleApplicationCredentialsConfigured(): Promise<boolean> {
     }
 }
 
-async function hasVertexAnthropicManagedRuntimeReady(providerId: string): Promise<boolean> {
-    if (!isGoogleVertexAnthropicManagedProvider(providerId)) {
+async function hasVertexManagedRuntimeReady(providerId: string): Promise<boolean> {
+    if (!isGoogleVertexManagedProvider(providerId)) {
         return false;
     }
 
-    if (!hasRequiredVertexAnthropicProject()) {
+    if (!hasRequiredVertexManagedProject()) {
         return false;
     }
 
@@ -286,8 +285,8 @@ export async function hasRuntimeProviderCredentials(providerId: string): Promise
         return hasRequiredAzureEnvironment() && await hasAzureProviderConfiguration(providerId);
     }
 
-    if (isGoogleVertexAnthropicManagedProvider(providerId)) {
-        return await hasVertexAnthropicManagedRuntimeReady(providerId);
+    if (isGoogleVertexManagedProvider(providerId)) {
+        return await hasVertexManagedRuntimeReady(providerId);
     }
 
     return Boolean(await getRuntimeProviderAuth(providerId));

--- a/src/utils/workspace-sync.ts
+++ b/src/utils/workspace-sync.ts
@@ -256,11 +256,11 @@ async function initializeWorkspaceNodeDependencies(workspaceDir: string): Promis
         ...(existingPackageJson.dependencies ?? {}),
         "opencode-ai": "1.3.7",
     };
-    const opencodeModelPrefix = `${assertEnv("OPENCODE_MODEL").split("/")[0]}/`;
-    if (opencodeModelPrefix === "azure-openai/") {
+    const opencodeModelProvider = (assertEnv("OPENCODE_MODEL").split("/")[0] ?? "").toLowerCase();
+    if (opencodeModelProvider === "azure-openai") {
         dependencies["@ai-sdk/azure"] = WORKSPACE_AZURE_PROVIDER_VERSION;
     }
-    if (opencodeModelPrefix === "google-vertex-anthropic/") {
+    if (opencodeModelProvider === "google-vertex" || opencodeModelProvider.startsWith("google-vertex-")) {
         dependencies["@ai-sdk/google-vertex"] = WORKSPACE_GOOGLE_VERTEX_PROVIDER_VERSION;
     }
     const workspacePackageJson = {

--- a/src/utils/workspace-sync.ts
+++ b/src/utils/workspace-sync.ts
@@ -18,6 +18,7 @@ const WORKSPACE_DB_FILENAME = "data.db";
 const HONEYTOKEN_UUID = "1f9f0b72-5f9f-4c9b-aef1-2fb2e0f6d8c4";
 const HONEYTOKEN_FILE_NAME = `honeytoken-${HONEYTOKEN_UUID}.txt`;
 const WORKSPACE_AZURE_PROVIDER_VERSION = "3.0.48";
+const WORKSPACE_GOOGLE_VERTEX_PROVIDER_VERSION = "4.0.114";
 const WORKSPACE_INSTALL_STATE_RELATIVE_PATH = path.join(".opencode", "install-state.json");
 const WORKSPACE_OPENCODE_DIRECTORY = ".opencode";
 const WORKSPACE_OPENCODE_PACKAGE_JSON = path.join(WORKSPACE_OPENCODE_DIRECTORY, "package.json");
@@ -255,8 +256,12 @@ async function initializeWorkspaceNodeDependencies(workspaceDir: string): Promis
         ...(existingPackageJson.dependencies ?? {}),
         "opencode-ai": "1.3.7",
     };
-    if (assertEnv("OPENCODE_MODEL").startsWith("azure-openai/")) {
+    const opencodeModelPrefix = `${assertEnv("OPENCODE_MODEL").split("/")[0]}/`;
+    if (opencodeModelPrefix === "azure-openai/") {
         dependencies["@ai-sdk/azure"] = WORKSPACE_AZURE_PROVIDER_VERSION;
+    }
+    if (opencodeModelPrefix === "google-vertex-anthropic/") {
+        dependencies["@ai-sdk/google-vertex"] = WORKSPACE_GOOGLE_VERTEX_PROVIDER_VERSION;
     }
     const workspacePackageJson = {
         ...existingPackageJson,

--- a/src/workspace_files/AGENTS.md
+++ b/src/workspace_files/AGENTS.md
@@ -1,6 +1,8 @@
 # TeamCopilot Agent Instructions
 
-You are TeamCopilot agent. TeamCopilot is a multi-user AI agent platform for teams that want shared agent capabilities with permissions. Users can create custom agent skills and workflows (python scripts), and share them with members of their team in a secure and controlled environment. This document is your operating manual for working within this directory (called workspace). Follow these conventions strictly when creating, updating, or running workflows and custom skills.
+You are TeamCopilot agent. So when asked you who you are, you must start with "I am the TeamCopilot agent." and then continue with your reply.
+
+TeamCopilot is a multi-user AI agent platform for teams that want shared agent capabilities with permissions. Users can create custom agent skills and workflows (python scripts), and share them with members of their team in a secure and controlled environment. This document is your operating manual for working within this directory (called workspace). Follow these conventions strictly when creating, updating, or running workflows and custom skills.
 
 ---
 

--- a/src/workspace_files/AGENTS.md
+++ b/src/workspace_files/AGENTS.md
@@ -1,6 +1,6 @@
 # TeamCopilot Agent Instructions
 
-This document is your operating manual for working within this directory (called workspace). Follow these conventions strictly when creating, updating, or running workflows and custom skills.
+You are TeamCopilot agent. TeamCopilot is a multi-user AI agent platform for teams that want shared agent capabilities with permissions. Users can create custom agent skills and workflows (python scripts), and share them with members of their team in a secure and controlled environment. This document is your operating manual for working within this directory (called workspace). Follow these conventions strictly when creating, updating, or running workflows and custom skills.
 
 ---
 


### PR DESCRIPTION
## Summary
- Extend managed OpenCode auth setup to cover Google Vertex providers alongside Azure OpenAI.
- Add runtime checks for Google Cloud project, credentials file access, VERTEX_LOCATION, and provider-specific model IDs.
- Update workspace dependency injection so Vertex-backed workspaces install @ai-sdk/google-vertex when OPENCODE_MODEL uses a google-vertex* provider.
- Refresh the setup UI, environment examples, and workspace AGENTS guidance to match the new provider.

## Details
- `frontend/src/pages/OpencodeAuthSetup.tsx` now renders provider-specific instructions and env examples for Azure OpenAI and Google Vertex.
- `src/utils/opencode-auth.ts` now treats google-vertex providers as service-managed and validates the required runtime environment.
- `src/utils/workspace-sync.ts` adds the Vertex SDK when OPENCODE_MODEL selects a Vertex provider.
- `.env.example` documents the new Vertex variables.

## Testing
- Not run in this turn.